### PR TITLE
feat: integrate vue-i18n for route titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "sm-crypto": "^0.3.13",
     "vant": "^4.9.0",
     "vue": "^3.4.38",
-    "vue-router": "^4.4.5"
+    "vue-router": "^4.4.5",
+    "vue-i18n": "^9.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/public/images/me/join-strip.svg
+++ b/public/images/me/join-strip.svg
@@ -1,0 +1,9 @@
+<svg width="702" height="60" viewBox="0 0 702 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="702" height="60" rx="16" fill="url(#paint0_linear_1_1)"/>
+  <defs>
+    <linearGradient id="paint0_linear_1_1" x1="0" y1="0" x2="702" y2="60" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3060ED"/>
+      <stop offset="1" stop-color="#5F8FFF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/layouts/TabLayout.vue
+++ b/src/layouts/TabLayout.vue
@@ -10,7 +10,7 @@
         :to="{ name: r.name }"
         :icon="r.meta.icon"
       >
-        {{ r.meta.title }}
+        {{ t(r.meta.title) }}
       </van-tabbar-item>
     </van-tabbar>
   </div>
@@ -18,12 +18,15 @@
 
 <script setup>
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import router from '@/router';
 
 // 只拿需要出现在底部的叶子路由
 const tabRoutes = computed(() =>
   router.getRoutes().filter((r) => r.meta?.tabbar && r.name && !r.children?.length)
 );
+
+const { t } = useI18n();
 </script>
 
 <style scoped>

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -3,6 +3,15 @@ export default {
     home: 'Home',
     apps: 'Applications',
     me: 'Profile',
+    meChildren: {
+      points: 'My Points',
+      leave: 'Leave Days (Monthly)',
+      travel: 'Travel Days (Monthly)',
+      overtime: 'Overtime Hours (Monthly)',
+      punch: 'Today\'s Punches',
+      workTime: 'Work Time Lookup',
+      punchRecord: 'Punch History',
+    },
     recruit: {
       campusList: 'Campus Positions',
       campusApply: 'Campus Application',
@@ -11,6 +20,30 @@ export default {
   },
   me: {
     navTitle: 'Profile',
+    dashboard: {
+      pointsLabel: 'My Points',
+      joinDays: 'With Dongchuang for {days} days',
+      metrics: {
+        leave: 'Leave days this month',
+        travel: 'Travel days this month',
+        overtime: 'Overtime hours this month',
+      },
+      todayPunch: {
+        title: 'Today\'s Punches',
+        timeLabel: 'Punch Time',
+        empty: 'No punches recorded today',
+      },
+      functions: {
+        title: 'My Shortcuts',
+        items: {
+          workTime: 'Work time inquiry',
+          punchRecord: 'Punch history',
+        },
+      },
+    },
+    placeholder: {
+      default: 'This feature is under preparation',
+    },
     language: {
       title: 'Language',
       zhCN: 'Chinese',

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -9,4 +9,55 @@ export default {
       campusApplyDetail: 'Application Details',
     },
   },
+  me: {
+    navTitle: 'Profile',
+    language: {
+      title: 'Language',
+      zhCN: 'Chinese',
+      enUS: 'English',
+    },
+    profile: {
+      unnamed: 'Unnamed User',
+      account: 'Account',
+    },
+    cells: {
+      position: 'Position',
+      role: 'Role',
+      joinedDate: 'Onboard Date',
+      email: 'Email',
+    },
+    actions: {
+      changePassword: 'Change Password',
+      logout: 'Log Out',
+    },
+    form: {
+      title: 'Change Password',
+      oldPassword: {
+        label: 'Current Password',
+        placeholder: 'Enter current password',
+      },
+      newPassword: {
+        label: 'New Password',
+        placeholder: 'Enter new password',
+      },
+      confirmPassword: {
+        label: 'Confirm Password',
+        placeholder: 'Re-enter new password',
+      },
+      cancel: 'Cancel',
+      confirm: 'Confirm',
+    },
+    validation: {
+      newPassword: 'Password must be at least 6 characters',
+      confirmPassword: 'The passwords do not match',
+    },
+    dialog: {
+      logoutTitle: 'Confirm Sign-out',
+      logoutMessage: 'Are you sure you want to sign out?',
+    },
+    toast: {
+      changePasswordSuccess: 'Password updated',
+      changePasswordFail: 'Update failed',
+    },
+  },
 };

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -26,7 +26,7 @@ export default {
       metrics: {
         leave: 'Leave days this month',
         travel: 'Travel days this month',
-        overtime: 'Overtime hours this month',
+        overtime: 'Overtime this month (h)',
       },
       todayPunch: {
         title: 'Today\'s Punches',

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1,0 +1,12 @@
+export default {
+  routes: {
+    home: 'Home',
+    apps: 'Applications',
+    me: 'Profile',
+    recruit: {
+      campusList: 'Campus Positions',
+      campusApply: 'Campus Application',
+      campusApplyDetail: 'Application Details',
+    },
+  },
+};

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,0 +1,27 @@
+import { createI18n } from 'vue-i18n';
+import zhCN from './zh-CN';
+import enUS from './en-US';
+
+const defaultLocale = 'zh-CN';
+
+const i18n = createI18n({
+  legacy: false,
+  globalInjection: true,
+  locale: defaultLocale,
+  fallbackLocale: defaultLocale,
+  messages: {
+    'zh-CN': zhCN,
+    'en-US': enUS,
+  },
+});
+
+export function translate(key, fallback = '') {
+  if (!key) return fallback;
+  const translated = i18n.global.t(key);
+  if (translated === key) {
+    return fallback || key;
+  }
+  return translated;
+}
+
+export default i18n;

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -3,16 +3,44 @@ import zhCN from './zh-CN';
 import enUS from './en-US';
 
 const defaultLocale = 'zh-CN';
+const messages = {
+  'zh-CN': zhCN,
+  'en-US': enUS,
+};
+
+const LOCALE_STORAGE_KEY = 'app-locale';
+
+function readStoredLocale() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage?.getItem(LOCALE_STORAGE_KEY);
+    if (stored && Object.prototype.hasOwnProperty.call(messages, stored)) {
+      return stored;
+    }
+  } catch (err) {
+    // 忽略 storage 读取异常
+  }
+  return null;
+}
+
+function detectBrowserLocale() {
+  if (typeof navigator === 'undefined') return null;
+  const language = navigator.language || navigator.userLanguage;
+  if (!language) return null;
+  const normalized = language.toLowerCase();
+  if (normalized.startsWith('zh')) return 'zh-CN';
+  if (normalized.startsWith('en')) return 'en-US';
+  return null;
+}
+
+const initialLocale = readStoredLocale() || detectBrowserLocale() || defaultLocale;
 
 const i18n = createI18n({
   legacy: false,
   globalInjection: true,
-  locale: defaultLocale,
+  locale: initialLocale,
   fallbackLocale: defaultLocale,
-  messages: {
-    'zh-CN': zhCN,
-    'en-US': enUS,
-  },
+  messages,
 });
 
 export function translate(key, fallback = '') {
@@ -23,5 +51,21 @@ export function translate(key, fallback = '') {
   }
   return translated;
 }
+
+export function changeLocale(nextLocale) {
+  if (!nextLocale || !Object.prototype.hasOwnProperty.call(messages, nextLocale)) {
+    return;
+  }
+  i18n.global.locale.value = nextLocale;
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage?.setItem(LOCALE_STORAGE_KEY, nextLocale);
+    } catch (err) {
+      // 忽略 storage 写入异常
+    }
+  }
+}
+
+export { LOCALE_STORAGE_KEY };
 
 export default i18n;

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1,0 +1,12 @@
+export default {
+  routes: {
+    home: '首页',
+    apps: '应用',
+    me: '我的',
+    recruit: {
+      campusList: '校招岗位列表',
+      campusApply: '校招投递表单',
+      campusApplyDetail: '投递详情',
+    },
+  },
+};

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -26,7 +26,7 @@ export default {
       metrics: {
         leave: '本月请假天数',
         travel: '本月出差天数',
-        overtime: '本月加班（小时）',
+        overtime: '本月加班（h）',
       },
       todayPunch: {
         title: '今日打卡',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -3,6 +3,15 @@ export default {
     home: '首页',
     apps: '应用',
     me: '我的',
+    meChildren: {
+      points: '我的积分',
+      leave: '本月请假天数',
+      travel: '本月出差天数',
+      overtime: '本月加班',
+      punch: '今日打卡',
+      workTime: '工时查询',
+      punchRecord: '打卡记录',
+    },
     recruit: {
       campusList: '校招岗位列表',
       campusApply: '校招投递表单',
@@ -11,6 +20,30 @@ export default {
   },
   me: {
     navTitle: '我的',
+    dashboard: {
+      pointsLabel: '我的积分',
+      joinDays: '加入东创{days}天',
+      metrics: {
+        leave: '本月请假天数',
+        travel: '本月出差天数',
+        overtime: '本月加班（小时）',
+      },
+      todayPunch: {
+        title: '今日打卡',
+        timeLabel: '打卡时间',
+        empty: '今日暂无打卡记录',
+      },
+      functions: {
+        title: '我的功能',
+        items: {
+          workTime: '工时查询',
+          punchRecord: '打卡记录',
+        },
+      },
+    },
+    placeholder: {
+      default: '功能开发中，敬请期待',
+    },
     language: {
       title: '语言',
       zhCN: '中文',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -9,4 +9,55 @@ export default {
       campusApplyDetail: '投递详情',
     },
   },
+  me: {
+    navTitle: '我的',
+    language: {
+      title: '语言',
+      zhCN: '中文',
+      enUS: '英文',
+    },
+    profile: {
+      unnamed: '未命名用户',
+      account: '账号',
+    },
+    cells: {
+      position: '职位',
+      role: '角色',
+      joinedDate: '入职时间',
+      email: '邮箱',
+    },
+    actions: {
+      changePassword: '修改密码',
+      logout: '退出登录',
+    },
+    form: {
+      title: '修改密码',
+      oldPassword: {
+        label: '旧密码',
+        placeholder: '请输入旧密码',
+      },
+      newPassword: {
+        label: '新密码',
+        placeholder: '请输入新密码',
+      },
+      confirmPassword: {
+        label: '确认密码',
+        placeholder: '请再次输入新密码',
+      },
+      cancel: '取消',
+      confirm: '确定',
+    },
+    validation: {
+      newPassword: '密码至少6位',
+      confirmPassword: '两次输入不一致',
+    },
+    dialog: {
+      logoutTitle: '确认退出',
+      logoutMessage: '确定要退出登录吗？',
+    },
+    toast: {
+      changePasswordSuccess: '修改成功',
+      changePasswordFail: '修改失败',
+    },
+  },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 // src/main.js
 import { createApp } from 'vue';
-import { createPinia } from 'pinia';
+import { createPinia, setActivePinia } from 'pinia';
 import App from './App.vue';
 import router from '@/router';
 import i18n from './locales';
@@ -25,6 +25,7 @@ async function bootstrap() {
   // 1) 状态 & 路由
   const pinia = createPinia();
   app.use(pinia);
+  setActivePinia(pinia);
   app.use(vant);
   app.use(i18n);
   app.use(router);

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from '@/router';
+import i18n from './locales';
 
 // 样式
 import 'nprogress/nprogress.css';
@@ -25,6 +26,7 @@ async function bootstrap() {
   const pinia = createPinia();
   app.use(pinia);
   app.use(vant);
+  app.use(i18n);
   app.use(router);
   app.use(plugins);
   setupRouterGuard(router);

--- a/src/permission.js
+++ b/src/permission.js
@@ -2,7 +2,8 @@
 import router from './router';
 import { useAuthStore } from '@/store/auth';
 import NProgress from 'nprogress';
-import { translate } from './locales';
+import { watch } from 'vue';
+import i18n, { translate } from './locales';
 
 function setTitle(meta) {
   const baseTitle = '联合东创';
@@ -18,6 +19,14 @@ function setTitle(meta) {
 
   document.title = resolved ? `${baseTitle}-${resolved}` : baseTitle;
 }
+
+watch(
+  () => i18n.global.locale.value,
+  () => {
+    const { meta } = router.currentRoute.value || {};
+    setTitle(meta);
+  }
+);
 
 // ✅ 与 axios 401 拦截器共享的一套工具
 import {

--- a/src/permission.js
+++ b/src/permission.js
@@ -2,9 +2,21 @@
 import router from './router';
 import { useAuthStore } from '@/store/auth';
 import NProgress from 'nprogress';
+import { translate } from './locales';
 
-function setTitle(title) {
-  if (title) document.title = `联合东创-${title}`;
+function setTitle(meta) {
+  const baseTitle = '联合东创';
+  if (!meta) {
+    document.title = baseTitle;
+    return;
+  }
+
+  const isString = typeof meta === 'string';
+  const titleKey = isString ? meta : meta.title;
+  const fallback = isString ? meta : meta.titleFallback ?? meta.title;
+  const resolved = translate(titleKey, fallback);
+
+  document.title = resolved ? `${baseTitle}-${resolved}` : baseTitle;
 }
 
 // ✅ 与 axios 401 拦截器共享的一套工具
@@ -50,7 +62,7 @@ router.beforeEach(async (to, from, next) => {
   }
 
   NProgress.start();
-  setTitle(to.meta?.title);
+  setTitle(to.meta);
 
   const auth = useAuthStore();
   const token = auth.token;

--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -1,6 +1,6 @@
 export default {
   path: 'apps',
   name: 'AppCenter',
-  meta: { title: '应用', icon: 'todo-list-o', tabbar: true, requiresAuth: true },
+  meta: { title: 'routes.apps', icon: 'todo-list-o', tabbar: true, requiresAuth: true },
   component: () => import('@/views/apps/index.vue'),
 };

--- a/src/router/modules/home.js
+++ b/src/router/modules/home.js
@@ -1,6 +1,6 @@
 export default {
   path: 'home',
   name: 'home',
-  meta: { title: '首页', icon: 'home-o', tabbar: true, requiresAuth: true },
+  meta: { title: 'routes.home', icon: 'home-o', tabbar: true, requiresAuth: true },
   component: () => import('@/views/home/index.vue'),
 }

--- a/src/router/modules/me.js
+++ b/src/router/modules/me.js
@@ -3,4 +3,76 @@ export default {
   name: 'me',
   meta: { title: 'routes.me', icon: 'user-o', tabbar: true, requiresAuth: true },
   component: () => import('@/views/account/Me.vue'),
-}
+  children: [
+    {
+      path: 'points',
+      name: 'mePoints',
+      meta: {
+        title: 'routes.meChildren.points',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'leave',
+      name: 'meLeave',
+      meta: {
+        title: 'routes.meChildren.leave',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'travel',
+      name: 'meTravel',
+      meta: {
+        title: 'routes.meChildren.travel',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'overtime',
+      name: 'meOvertime',
+      meta: {
+        title: 'routes.meChildren.overtime',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'punch',
+      name: 'mePunch',
+      meta: {
+        title: 'routes.meChildren.punch',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'work-time',
+      name: 'meWorkTime',
+      meta: {
+        title: 'routes.meChildren.workTime',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+    {
+      path: 'punch-record',
+      name: 'mePunchRecord',
+      meta: {
+        title: 'routes.meChildren.punchRecord',
+        requiresAuth: true,
+        placeholderKey: 'me.placeholder.default',
+      },
+      component: () => import('@/views/account/me/Placeholder.vue'),
+    },
+  ],
+};

--- a/src/router/modules/me.js
+++ b/src/router/modules/me.js
@@ -1,6 +1,6 @@
 export default {
   path: 'me',
   name: 'me',
-  meta: { title: '我的', icon: 'user-o', tabbar: true, requiresAuth: true },
+  meta: { title: 'routes.me', icon: 'user-o', tabbar: true, requiresAuth: true },
   component: () => import('@/views/account/Me.vue'),
 }

--- a/src/router/modules/recruit.js
+++ b/src/router/modules/recruit.js
@@ -11,13 +11,13 @@ export default {
         {
           path: 'list', // 校招岗位列表
           name: 'recruit-campus-list',
-          meta: { title: '校招岗位列表', requiresAuth: true },
+          meta: { title: 'routes.recruit.campusList', requiresAuth: true },
           component: () => import('@/views/recruit/campus/list.vue'),
         },
         {
           path: 'apply', // 校招投递表单
           name: 'recruit-campus-apply',
-          meta: { title: '校招投递表单', requiresAuth: false },
+          meta: { title: 'routes.recruit.campusApply', requiresAuth: false },
           beforeEnter: ensureAuthRouteGuard({ type: 'campus_applicant', mode: 'social' }),
           component: () => import('@/views/recruit/campus/apply.vue'),
         },
@@ -25,7 +25,7 @@ export default {
         {
           path: 'apply-detail/:applyId?', // 可带投递ID；没有ID也可通过query传status
           name: 'recruit-campus-apply-detail',
-          meta: { title: '投递详情', requiresAuth: false },
+          meta: { title: 'routes.recruit.campusApplyDetail', requiresAuth: false },
           component: () => import('@/views/recruit/campus/apply-detail.vue'),
         },
       ],

--- a/src/utils/normalize-user.js
+++ b/src/utils/normalize-user.js
@@ -8,6 +8,29 @@ const csv = (s) =>
         .filter(Boolean)
     : [];
 
+const toNumber = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const toArray = (value) => {
+  if (Array.isArray(value)) return value.map((item) => String(item));
+  if (value == null || value === '') return [];
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.map((item) => String(item));
+    } catch (err) {
+      // fall through to comma split handling
+    }
+    return value
+      .split(/[\n,]/)
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [String(value)];
+};
+
 export function normalizeUser(data = {}) {
   // 你的后端字段（原始）
   // 例如：id、tenantId、account、name、realName、roleId、roleName、postId、postName、deptId、deptName 等
@@ -82,5 +105,13 @@ export function normalizeUser(data = {}) {
     userId: data.id, // 常见别名
     username: data.account, // 你们账号形态
     real_name: data.realName, // 某些老代码习惯
+
+    // 扩展：个人工作台统计
+    points: toNumber(data.points),
+    leaveDateCount: toNumber(data.leaveDateCount),
+    travelDateCount: toNumber(data.travelDateCount),
+    overDateCount: toNumber(data.overDateCount),
+    joinDateCount: toNumber(data.joinDateCount),
+    punchCardDetail: toArray(data.punchCardDetail),
   };
 }

--- a/src/views/account/Me.vue
+++ b/src/views/account/Me.vue
@@ -1,127 +1,125 @@
 <template>
-  <div class="me-page">
-    <van-nav-bar :title="t('me.navTitle')" fixed />
+  <div class="mine-page">
+    <div class="top-bg"></div>
+    <van-nav-bar
+      :title="t('me.navTitle')"
+      fixed
+      :border="false"
+      class="mine-nav"
+      safe-area-inset-top
+    />
 
-    <div class="me-header" :style="{ paddingTop: '54px' }">
-      <div class="me-profile">
-        <img
-          class="avatar"
-          :src="user.avatar || defaultAvatar"
-          alt="avatar"
-          @error="onAvatarError"
-        />
-        <div class="meta">
-          <div class="name">
-            {{ user.realName || user.name || user.username || t('me.profile.unnamed') }}
-            <van-tag v-if="user.deptName" plain type="primary" class="ml8">{{
-              user.deptName
-            }}</van-tag>
+    <section class="profile-card">
+      <div class="bg-index bg-index-2"></div>
+      <div class="bg-index bg-index-1"></div>
+
+      <div class="profile-top">
+        <div class="userinfo-wrap">
+          <div class="userinfo-wrap-left">
+            <div class="avatar-and-userinfo">
+              <img
+                class="avatar"
+                :src="user.avatar || defaultAvatar"
+                alt="avatar"
+                @error="onAvatarError"
+              />
+              <div class="col">
+                <span class="name"
+                  >{{ user.realName || user.name || user.username || t('me.profile.unnamed') }}</span
+                >
+                <span class="uid">{{ user.account || '-' }}</span>
+              </div>
+            </div>
+            <div v-if="roleTags.length" class="tags">
+              <span class="tag" v-for="(tag, idx) in roleTags" :key="idx">{{ tag }}</span>
+            </div>
           </div>
-          <div class="sub">
-            <span v-if="user.account">{{ t('me.profile.account') }}：{{ user.account }}</span>
-            <span v-if="user.phone" class="dot">·</span>
-            <span v-if="user.phone">{{ user.phone }}</span>
+          <div class="points-card" @click="navigateToRoute('mePoints')">
+            <span class="points-label">{{ t('me.dashboard.pointsLabel') }}</span>
+            <span class="points-val">{{ stats.pointsDisplay }}</span>
           </div>
         </div>
       </div>
 
-      <div class="me-dashboard">
+      <div class="stats">
         <button
+          v-for="metric in metrics"
+          :key="metric.key"
           type="button"
-          class="points-card interactive"
-          @click="navigateToRoute('mePoints')"
+          class="stat"
+          @click="navigateToRoute(metric.routeName)"
         >
-          <span class="points-label">{{ t('me.dashboard.pointsLabel') }}</span>
-          <span class="points-value">{{ stats.pointsDisplay }}</span>
-          <span class="points-meta">{{ joinDaysText }}</span>
+          <span class="stat-label">{{ metric.label }}</span>
+          <span class="stat-num">{{ metric.display }}</span>
         </button>
-
-        <div class="metrics-grid">
-          <button
-            v-for="metric in metrics"
-            :key="metric.key"
-            type="button"
-            class="metric interactive"
-            @click="navigateToRoute(metric.routeName)"
-          >
-            <span class="metric-label">{{ metric.label }}</span>
-            <span class="metric-value">{{ metric.display }}</span>
-          </button>
-        </div>
       </div>
-    </div>
 
-    <div class="me-body">
-      <section class="me-card interactive" @click="navigateToRoute('mePunch')">
-        <div class="card-title-row">
-          <span class="card-title">{{ t('me.dashboard.todayPunch.title') }}</span>
-          <van-icon name="arrow" class="card-arrow" />
-        </div>
+      <div class="join-strip" :style="joinStripStyle">{{ joinDaysText }}</div>
+    </section>
 
-        <div v-if="punchRecords.length" class="timeline">
-          <div class="timeline-item" v-for="(time, index) in punchRecords" :key="index">
-            <div class="timeline-left">
-              <span class="timeline-dot"></span>
-              <span
-                v-if="index !== punchRecords.length - 1"
-                class="timeline-line"
-              ></span>
-            </div>
-            <div class="timeline-content">
-              <div class="timeline-title">{{ t('me.dashboard.todayPunch.timeLabel') }}</div>
-              <div class="timeline-time">{{ time }}</div>
-            </div>
+    <section class="card punch-card" @click="navigateToRoute('mePunch')">
+      <div class="card-title-row">
+        <span class="card-title">{{ t('me.dashboard.todayPunch.title') }}</span>
+        <van-icon name="arrow" class="arrow" />
+      </div>
+      <div class="timeline" v-if="punchRecords.length">
+        <div class="tl-item" v-for="(time, index) in punchRecords" :key="index">
+          <div class="tl-left">
+            <span class="dot done"></span>
+            <span v-if="index !== punchRecords.length - 1" class="line"></span>
+          </div>
+          <div class="tl-content">
+            <div class="tl-title">{{ t('me.dashboard.todayPunch.timeLabel') }}</div>
+            <div class="tl-time">{{ time }}</div>
           </div>
         </div>
-        <div v-else class="timeline-empty">{{ t('me.dashboard.todayPunch.empty') }}</div>
-      </section>
+      </div>
+      <div v-else class="timeline-empty">{{ t('me.dashboard.todayPunch.empty') }}</div>
+    </section>
 
-      <section class="me-card">
-        <div class="card-title-row">
-          <span class="card-title">{{ t('me.dashboard.functions.title') }}</span>
-        </div>
-        <div class="func-grid">
-          <button
-            v-for="item in functionItems"
-            :key="item.key"
-            type="button"
-            class="func-item interactive"
-            @click="handleFunction(item)"
-          >
-            <span class="func-icon">
-              <van-icon :name="item.icon" />
-            </span>
-            <span class="func-text">{{ item.label }}</span>
-          </button>
-        </div>
-      </section>
+    <section class="card func-card">
+      <div class="card-title-row">
+        <span class="card-title">{{ t('me.dashboard.functions.title') }}</span>
+      </div>
+      <div class="func-grid">
+        <button
+          v-for="item in functionItems"
+          :key="item.key"
+          type="button"
+          class="func-item"
+          @click="handleFunction(item)"
+        >
+          <span class="func-icon">
+            <van-icon :name="item.icon" />
+          </span>
+          <span class="func-text">{{ item.label }}</span>
+        </button>
+      </div>
+    </section>
 
-      <van-cell-group inset class="mt12">
-        <van-cell :title="t('me.language.title')">
-          <template #right-icon>
-            <van-radio-group v-model="selectedLocale" direction="horizontal">
-              <van-radio name="zh-CN">{{ t('me.language.zhCN') }}</van-radio>
-              <van-radio name="en-US">{{ t('me.language.enUS') }}</van-radio>
-            </van-radio-group>
-          </template>
-        </van-cell>
-      </van-cell-group>
+    <van-cell-group inset class="mt12">
+      <van-cell :title="t('me.language.title')">
+        <template #right-icon>
+          <van-radio-group v-model="selectedLocale" direction="horizontal">
+            <van-radio name="zh-CN">{{ t('me.language.zhCN') }}</van-radio>
+            <van-radio name="en-US">{{ t('me.language.enUS') }}</van-radio>
+          </van-radio-group>
+        </template>
+      </van-cell>
+    </van-cell-group>
 
-      <!-- 只展示：职位、角色、入职时间、邮箱 -->
-      <van-cell-group inset class="mt12">
-        <van-cell :title="t('me.cells.position')" :value="postText" />
-        <van-cell :title="t('me.cells.role')" :value="roleText" />
-        <van-cell :title="t('me.cells.joinedDate')" :value="joinedDateText" />
-        <van-cell :title="t('me.cells.email')" :value="user.email || '-'" />
-      </van-cell-group>
+    <van-cell-group inset class="mt12">
+      <van-cell :title="t('me.cells.position')" :value="postText" />
+      <van-cell :title="t('me.cells.role')" :value="roleText" />
+      <van-cell :title="t('me.cells.joinedDate')" :value="joinedDateText" />
+      <van-cell :title="t('me.cells.email')" :value="user.email || '-'" />
+    </van-cell-group>
 
-      <van-cell-group inset class="mt12">
-        <van-cell :title="t('me.actions.changePassword')" is-link @click="openPwdPopup" />
-        <van-cell :title="t('me.actions.logout')" is-link @click="confirmLogout" />
-      </van-cell-group>
-    </div>
+    <van-cell-group inset class="mt12">
+      <van-cell :title="t('me.actions.changePassword')" is-link @click="openPwdPopup" />
+      <van-cell :title="t('me.actions.logout')" is-link @click="confirmLogout" />
+    </van-cell-group>
 
-    <!-- 修改密码 -->
     <van-popup
       v-model:show="pwd.show"
       position="bottom"
@@ -287,18 +285,28 @@ function handleFunction(item) {
   navigateToRoute(item.routeName);
 }
 
-// 工具：数组/逗号字符串 → 文本
-const toNiceText = (v) => {
-  if (!v) return '';
-  if (Array.isArray(v)) return v.filter(Boolean).join('、') || '';
-  return (
-    String(v)
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .join('、') || ''
-  );
+// 工具：数组/逗号字符串 → 数组
+const toArrayValue = (v) => {
+  if (!v) return [];
+  if (Array.isArray(v)) {
+    return v
+      .map((item) => String(item).trim())
+      .filter(Boolean);
+  }
+  return String(v)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 };
+
+// 展示文本
+const toNiceText = (v) => toArrayValue(v).join('、') || '';
+
+const roleTags = computed(() => {
+  const tags = toArrayValue(user.value.roleNames);
+  if (tags.length) return tags;
+  return toArrayValue(user.value.roleName);
+});
 
 const roleText = computed(
   () => toNiceText(user.value.roleNames) || toNiceText(user.value.roleName) || '-'
@@ -316,6 +324,14 @@ const defaultAvatar = proxy.$assetUrl('/images/logo.png');
 const onAvatarError = (e) => {
   e.target.src = defaultAvatar;
 };
+
+const joinStripUrl = proxy.$assetUrl('/images/me/join-strip.svg');
+const joinStripStyle = computed(() => ({
+  backgroundImage: `url(${joinStripUrl})`,
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: 'cover',
+}));
 
 // 修改密码
 const pwd = reactive({
@@ -384,217 +400,307 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.me-page {
+.mine-page {
+  position: relative;
+  margin: 0 auto;
   min-height: 100vh;
-  background: #f7f8fa;
+  max-width: 750px;
+  padding: 56px 0 120px;
+  background: #f6f7fb;
 }
-.me-header {
+
+.top-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 240px;
+  background: linear-gradient(180deg, #3060ed 0%, rgba(48, 96, 237, 0.3) 64%, rgba(48, 96, 237, 0) 100%);
+  z-index: 0;
+}
+
+.mine-nav {
+  background: transparent;
+  color: #fff;
+  --van-nav-bar-title-text-color: #fff;
+  --van-nav-bar-icon-color: #fff;
+  --van-nav-bar-text-color: #fff;
+}
+
+.profile-card {
+  position: relative;
+  margin: 40px 16px 0;
+  padding: 24px;
   background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 12px 36px rgba(25, 81, 230, 0.08);
+  z-index: 1;
 }
-.me-profile {
+
+.bg-index {
+  position: absolute;
+  top: -12px;
+  left: 0;
+  width: calc(100% - 16px);
+  height: 260px;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 24px;
+  transform-origin: center;
+}
+
+.bg-index-1 {
+  z-index: -1;
+  transform: rotate(-4deg);
+}
+
+.bg-index-2 {
+  z-index: -2;
+  transform: rotate(-8deg);
+}
+
+.profile-top {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.userinfo-wrap {
+  display: flex;
+  align-items: stretch;
+  gap: 16px;
+}
+
+.userinfo-wrap-left {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.avatar-and-userinfo {
   display: flex;
   align-items: center;
-  padding: 16px;
+  gap: 12px;
 }
+
 .avatar {
   width: 64px;
   height: 64px;
-  border-radius: 50%;
+  border-radius: 16px;
   object-fit: cover;
+  border: 1px solid #dadbe0;
   background: #f2f3f5;
-  border: 1px solid #eee;
 }
-.meta {
-  margin-left: 12px;
-  flex: 1;
-  min-width: 0;
+
+.col {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
+
 .name {
-  font-size: 16px;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.sub {
-  margin-top: 6px;
-  color: #888;
-  font-size: 13px;
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-.dot::before {
-  content: '•';
-  margin-right: 6px;
-  color: #ccc;
-}
-.mt12 {
-  margin-top: 12px;
-}
-.ml8 {
-  margin-left: 8px;
-}
-.interactive {
-  cursor: pointer;
-  transition: transform 0.2s ease;
-}
-.interactive:active {
-  transform: scale(0.98);
-}
-.me-dashboard {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 0 16px 16px;
-}
-.points-card {
-  border: none;
-  outline: none;
-  border-radius: 16px;
-  padding: 20px 24px;
-  background: linear-gradient(135deg, #3060ed 0%, #5c87ff 100%);
-  color: #fff;
-  text-align: left;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font: inherit;
-}
-.points-label {
-  font-size: 14px;
-  opacity: 0.85;
-}
-.points-value {
-  font-size: 28px;
+  font-size: 18px;
   font-weight: 700;
+  color: #1f2b3d;
 }
-.points-meta {
+
+.uid {
   font-size: 13px;
-  opacity: 0.85;
+  color: #8c9aaf;
 }
-.metrics-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
-.metric {
-  border: none;
-  outline: none;
-  border-radius: 14px;
-  background: #f3f6ff;
-  padding: 14px 12px;
-  text-align: left;
-  color: #1f2b3d;
-  font: inherit;
-}
-.metric-label {
+
+.tag {
+  padding: 4px 10px;
+  border-radius: 12px;
+  background: #baccff;
+  color: #3060ed;
   font-size: 12px;
-  color: #5f6b7a;
 }
-.metric-value {
-  margin-top: 6px;
-  font-size: 20px;
-  font-weight: 600;
-}
-.me-body {
-  padding: 0 16px 24px;
-}
-.me-card {
-  background: #fff;
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 8px 24px rgba(48, 96, 237, 0.08);
-  margin-top: 16px;
-}
-.me-card:first-of-type {
-  margin-top: 0;
-}
-.card-title-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.card-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: #1f2b3d;
-}
-.card-arrow {
-  color: #c8cdd8;
-}
-.timeline {
-  margin-top: 16px;
-}
-.timeline-item {
-  display: flex;
-  align-items: flex-start;
-}
-.timeline-item + .timeline-item {
-  margin-top: 12px;
-}
-.timeline-left {
-  width: 24px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.timeline-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+
+.points-card {
+  width: 132px;
+  min-width: 132px;
+  height: 132px;
+  border-radius: 24px;
   background: #3060ed;
-  border: 3px solid #dbe4ff;
-  box-sizing: border-box;
-}
-.timeline-line {
-  flex: 1;
-  width: 2px;
-  margin-top: 6px;
-  background: linear-gradient(180deg, rgba(48, 96, 237, 0.2) 0%, rgba(48, 96, 237, 0) 100%);
-}
-.timeline-content {
-  flex: 1;
-  padding-left: 12px;
-}
-.timeline-title {
-  font-size: 12px;
-  color: #5f6b7a;
-}
-.timeline-time {
-  margin-top: 4px;
-  font-size: 16px;
-  font-weight: 500;
-  color: #1f2b3d;
-}
-.timeline-empty {
-  margin-top: 16px;
-  font-size: 13px;
-  color: #9aa2b1;
-}
-.func-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 16px;
-}
-.func-item {
-  border: none;
-  outline: none;
-  border-radius: 14px;
-  background: #f7f8fb;
-  padding: 16px 12px;
+  color: #fff;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  font: inherit;
+  border: none;
+  cursor: pointer;
 }
+
+.points-label {
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.points-val {
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 12px;
+  background: #f7f8ff;
+  border-radius: 16px;
+  border: none;
+  color: #1f2b3d;
+  cursor: pointer;
+}
+
+.stat-label {
+  font-size: 13px;
+  color: #8c9aaf;
+  text-align: center;
+}
+
+.stat-num {
+  font-size: 26px;
+  font-weight: 700;
+}
+
+.join-strip {
+  margin-top: 20px;
+  padding: 16px 24px;
+  border-radius: 20px;
+  background-color: #3060ed;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.card {
+  position: relative;
+  margin: 16px;
+  background: #fff;
+  border-radius: 24px;
+  box-shadow: 0 12px 36px rgba(25, 81, 230, 0.08);
+  padding: 20px 24px;
+}
+
+.punch-card {
+  cursor: pointer;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1f2b3d;
+}
+
+.arrow {
+  color: #c5ccda;
+}
+
+.timeline {
+  margin-top: 16px;
+}
+
+.tl-item {
+  display: flex;
+  gap: 12px;
+}
+
+.tl-item + .tl-item {
+  margin-top: 12px;
+}
+
+.tl-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #1d65f3;
+  border: 4px solid #b4cdff;
+  box-sizing: border-box;
+}
+
+.line {
+  flex: 1;
+  width: 2px;
+  margin-top: 6px;
+  border-left: 1px dashed #bbbbbb;
+}
+
+.tl-content {
+  flex: 1;
+}
+
+.tl-title {
+  font-size: 13px;
+  color: #5f6b7a;
+}
+
+.tl-time {
+  margin-top: 4px;
+  font-size: 16px;
+  color: #1f2b3d;
+  font-weight: 500;
+}
+
+.timeline-empty {
+  margin-top: 16px;
+  font-size: 13px;
+  color: #9aa2b1;
+}
+
+.func-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.func-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px 12px;
+  border-radius: 16px;
+  background: #f7f8fb;
+  border: none;
+  cursor: pointer;
+}
+
 .func-icon {
   width: 48px;
   height: 48px;
-  border-radius: 50%;
+  border-radius: 16px;
   background: #e4ebff;
   display: flex;
   align-items: center;
@@ -602,23 +708,41 @@ onMounted(() => {
   color: #3060ed;
   font-size: 24px;
 }
+
 .func-text {
   font-size: 14px;
-  color: #1f2b3d;
+  color: #353638;
 }
+
+.mt12 {
+  margin: 12px 16px 0;
+}
+
 .sheet {
   padding: 16px;
 }
+
 .sheet-title {
   text-align: center;
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 8px;
 }
+
 .action {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
   margin: 16px 0 8px;
+}
+
+.mr8 {
+  margin-right: 0;
+}
+
+button {
+  font: inherit;
+  border: none;
+  padding: 0;
 }
 </style>

--- a/src/views/account/Me.vue
+++ b/src/views/account/Me.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="me-page">
-    <van-nav-bar title="我的" fixed />
+    <van-nav-bar :title="t('me.navTitle')" fixed />
 
     <div class="me-header" :style="{ paddingTop: '54px' }">
       <div class="me-profile">
@@ -12,13 +12,13 @@
         />
         <div class="meta">
           <div class="name">
-            {{ user.realName || user.name || user.username || '未命名用户' }}
+            {{ user.realName || user.name || user.username || t('me.profile.unnamed') }}
             <van-tag v-if="user.deptName" plain type="primary" class="ml8">{{
               user.deptName
             }}</van-tag>
           </div>
           <div class="sub">
-            <span v-if="user.account">账号：{{ user.account }}</span>
+            <span v-if="user.account">{{ t('me.profile.account') }}：{{ user.account }}</span>
             <span v-if="user.phone" class="dot">·</span>
             <span v-if="user.phone">{{ user.phone }}</span>
           </div>
@@ -26,17 +26,28 @@
       </div>
     </div>
 
+    <van-cell-group inset class="mt12">
+      <van-cell :title="t('me.language.title')">
+        <template #right-icon>
+          <van-radio-group v-model="selectedLocale" direction="horizontal">
+            <van-radio name="zh-CN">{{ t('me.language.zhCN') }}</van-radio>
+            <van-radio name="en-US">{{ t('me.language.enUS') }}</van-radio>
+          </van-radio-group>
+        </template>
+      </van-cell>
+    </van-cell-group>
+
     <!-- 只展示：职位、角色、入职时间、邮箱 -->
     <van-cell-group inset class="mt12">
-      <van-cell title="职位" :value="postText" />
-      <van-cell title="角色" :value="roleText" />
-      <van-cell title="入职时间" :value="joinedDateText" />
-      <van-cell title="邮箱" :value="user.email || '-'" />
+      <van-cell :title="t('me.cells.position')" :value="postText" />
+      <van-cell :title="t('me.cells.role')" :value="roleText" />
+      <van-cell :title="t('me.cells.joinedDate')" :value="joinedDateText" />
+      <van-cell :title="t('me.cells.email')" :value="user.email || '-'" />
     </van-cell-group>
 
     <van-cell-group inset class="mt12">
-      <van-cell title="修改密码" is-link @click="openPwdPopup" />
-      <van-cell title="退出登录" is-link @click="confirmLogout" />
+      <van-cell :title="t('me.actions.changePassword')" is-link @click="openPwdPopup" />
+      <van-cell :title="t('me.actions.logout')" is-link @click="confirmLogout" />
     </van-cell-group>
 
     <!-- 修改密码 -->
@@ -48,39 +59,41 @@
       :style="{ height: 'auto' }"
     >
       <div class="sheet">
-        <div class="sheet-title">修改密码</div>
+        <div class="sheet-title">{{ t('me.form.title') }}</div>
         <van-form ref="pwdFormRef" @submit="submitChangePwd">
           <van-field
             v-model="pwd.oldPassword"
             type="password"
-            label="旧密码"
-            placeholder="请输入旧密码"
-            :rules="[{ required: true, message: '请输入旧密码' }]"
+            :label="t('me.form.oldPassword.label')"
+            :placeholder="t('me.form.oldPassword.placeholder')"
+            :rules="[{ required: true, message: t('me.form.oldPassword.placeholder') }]"
             clearable
           />
           <van-field
             v-model="pwd.newPassword"
             type="password"
-            label="新密码"
-            placeholder="请输入新密码"
+            :label="t('me.form.newPassword.label')"
+            :placeholder="t('me.form.newPassword.placeholder')"
             :rules="[
-              { required: true, message: '请输入新密码' },
-              { validator: validateNewPwd, message: '密码至少6位' },
+              { required: true, message: t('me.form.newPassword.placeholder') },
+              { validator: validateNewPwd, message: t('me.validation.newPassword') },
             ]"
             clearable
           />
           <van-field
             v-model="pwd.confirmPassword"
             type="password"
-            label="确认密码"
-            placeholder="请再次输入新密码"
-            :rules="[{ validator: validateConfirmPwd, message: '两次输入不一致' }]"
+            :label="t('me.form.confirmPassword.label')"
+            :placeholder="t('me.form.confirmPassword.placeholder')"
+            :rules="[{ validator: validateConfirmPwd, message: t('me.validation.confirmPassword') }]"
             clearable
           />
           <div class="action">
-            <van-button type="default" block class="mr8" @click="pwd.show = false">取消</van-button>
+            <van-button type="default" block class="mr8" @click="pwd.show = false"
+              >{{ t('me.form.cancel') }}</van-button
+            >
             <van-button type="primary" block native-type="submit" :loading="pwd.loading"
-              >确定</van-button
+              >{{ t('me.form.confirm') }}</van-button
             >
           </div>
         </van-form>
@@ -91,17 +104,29 @@
 
 <script setup>
 import { computed, reactive, ref, onMounted, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { showConfirmDialog, showToast } from 'vant';
 import { useAuthStore } from '@/store/auth';
 import { useUserStore } from '@/store/user';
 import Api from '@/api';
 import { encrypt } from '@/utils/sm2';
+import { changeLocale } from '@/locales';
 
 const { proxy } = getCurrentInstance();
 const router = useRouter();
 const auth = useAuthStore();
 const userStore = useUserStore();
+const { t, locale } = useI18n();
+
+const selectedLocale = computed({
+  get: () => locale.value,
+  set: (val) => {
+    if (val && val !== locale.value) {
+      changeLocale(val);
+    }
+  },
+});
 
 // 页面取用户信息：来自 user 仓库
 const user = computed(() => userStore.userInfo || {});
@@ -156,22 +181,23 @@ function validateConfirmPwd(v) {
 }
 
 async function submitChangePwd() {
-  if (!validateNewPwd(pwd.newPassword)) return showToast('密码至少6位');
-  if (!validateConfirmPwd(pwd.confirmPassword)) return showToast('两次输入不一致');
+  if (!validateNewPwd(pwd.newPassword)) return showToast(t('me.validation.newPassword'));
+  if (!validateConfirmPwd(pwd.confirmPassword))
+    return showToast(t('me.validation.confirmPassword'));
   try {
     pwd.loading = true;
     await Api.user.updatePassword({
       oldPassword: pwd.oldPassword,
       newPassword: pwd.newPassword,
     });
-    showToast('修改成功');
+    showToast(t('me.toast.changePasswordSuccess'));
     pwd.show = false;
     pwd.oldPassword = '';
     pwd.newPassword = '';
     pwd.confirmPassword = '';
     // await doLogout(true);
   } catch (err) {
-    showToast(err?.message || '修改失败');
+    showToast(err?.message || t('me.toast.changePasswordFail'));
   } finally {
     pwd.loading = false;
   }
@@ -179,7 +205,10 @@ async function submitChangePwd() {
 
 async function confirmLogout() {
   try {
-    await showConfirmDialog({ title: '确认退出', message: '确定要退出登录吗？' });
+    await showConfirmDialog({
+      title: t('me.dialog.logoutTitle'),
+      message: t('me.dialog.logoutMessage'),
+    });
     await doLogout();
   } catch {}
 }

--- a/src/views/account/Me.vue
+++ b/src/views/account/Me.vue
@@ -103,14 +103,13 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref, onMounted, getCurrentInstance } from 'vue';
+import { computed, reactive, ref, onMounted, getCurrentInstance, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { showConfirmDialog, showToast } from 'vant';
 import { useAuthStore } from '@/store/auth';
 import { useUserStore } from '@/store/user';
 import Api from '@/api';
-import { encrypt } from '@/utils/sm2';
 import { changeLocale } from '@/locales';
 
 const { proxy } = getCurrentInstance();
@@ -119,14 +118,23 @@ const auth = useAuthStore();
 const userStore = useUserStore();
 const { t, locale } = useI18n();
 
-const selectedLocale = computed({
-  get: () => locale.value,
-  set: (val) => {
-    if (val && val !== locale.value) {
+const selectedLocale = ref(locale.value);
+
+watch(locale, (val) => {
+  if (val && val !== selectedLocale.value) {
+    selectedLocale.value = val;
+  }
+});
+
+watch(
+  selectedLocale,
+  (val, oldVal) => {
+    if (val && val !== oldVal && val !== locale.value) {
       changeLocale(val);
     }
   },
-});
+  { flush: 'sync' }
+);
 
 // 页面取用户信息：来自 user 仓库
 const user = computed(() => userStore.userInfo || {});

--- a/src/views/account/me/Placeholder.vue
+++ b/src/views/account/me/Placeholder.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="me-placeholder">
+    <van-empty :description="description" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+
+const route = useRoute();
+const { t } = useI18n();
+
+const description = computed(() => {
+  const key = route.meta?.placeholderKey;
+  return key ? t(key) : t('me.placeholder.default');
+});
+</script>
+
+<style scoped>
+.me-placeholder {
+  min-height: calc(100vh - 96px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  background: #f7f8fa;
+}
+
+:deep(.van-empty__description) {
+  color: #5f6b7a;
+}
+</style>


### PR DESCRIPTION
## Summary
- add vue-i18n with zh-CN and en-US locale resources and register it during app bootstrap
- translate route metadata titles and update consumers to resolve labels through i18n

## Testing
- npm install *(fails: registry responded 403 when fetching vue-i18n)*

------
https://chatgpt.com/codex/tasks/task_e_68f03da66c808327907c771a04c01cb9