### PR TITLE
feat: add apps dashboard entries

### DIFF
--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -1,6 +1,84 @@
 export default {
   path: 'apps',
-  name: 'AppCenter',
-  meta: { title: 'routes.apps', icon: 'todo-list-o', tabbar: true, requiresAuth: true },
-  component: () => import('@/views/apps/index.vue'),
+  component: () => import('@/views/apps/Layout.vue'),
+  children: [
+    {
+      path: '',
+      name: 'apps',
+      meta: { title: 'routes.apps', icon: 'todo-list-o', tabbar: true, requiresAuth: true },
+      component: () => import('@/views/apps/index.vue'),
+    },
+    {
+      path: 'workflow-center',
+      name: 'appsWorkflowCenter',
+      meta: { title: '流程中心', requiresAuth: true },
+      component: () => import('@/views/apps/WorkflowCenter.vue'),
+    },
+    {
+      path: 'material-tracking',
+      name: 'appsMaterialTracking',
+      meta: { title: '料况跟进', requiresAuth: true },
+      component: () => import('@/views/apps/MaterialTracking.vue'),
+    },
+    {
+      path: 'inbound-order',
+      name: 'appsInboundOrder',
+      meta: { title: '入库单', requiresAuth: true },
+      component: () => import('@/views/apps/InboundOrder.vue'),
+    },
+    {
+      path: 'site-planning',
+      name: 'appsSitePlanning',
+      meta: { title: '现场计划单', requiresAuth: true },
+      component: () => import('@/views/apps/SitePlanning.vue'),
+    },
+    {
+      path: 'work-report',
+      name: 'appsWorkReport',
+      meta: { title: '工时汇报', requiresAuth: true },
+      component: () => import('@/views/apps/WorkReport.vue'),
+    },
+    {
+      path: 'picking-confirmation',
+      name: 'appsPickingConfirmation',
+      meta: { title: '确认领料', requiresAuth: true },
+      component: () => import('@/views/apps/PickingConfirmation.vue'),
+    },
+    {
+      path: 'material-maintenance',
+      name: 'appsMaterialMaintenance',
+      meta: { title: '物料信息维护', requiresAuth: true },
+      component: () => import('@/views/apps/MaterialMaintenance.vue'),
+    },
+    {
+      path: 'wire-inspection',
+      name: 'appsWireInspection',
+      meta: { title: '线材质检', requiresAuth: true },
+      component: () => import('@/views/apps/WireInspection.vue'),
+    },
+    {
+      path: 'shipment-upload',
+      name: 'appsShipmentUpload',
+      meta: { title: '出货资料上传', requiresAuth: true },
+      component: () => import('@/views/apps/ShipmentUpload.vue'),
+    },
+    {
+      path: 'outsourcing-quotation',
+      name: 'appsOutsourcingQuotation',
+      meta: { title: '外协核价', requiresAuth: true },
+      component: () => import('@/views/apps/OutsourcingQuotation.vue'),
+    },
+    {
+      path: 'self-outbound',
+      name: 'appsSelfOutbound',
+      meta: { title: '自助出库', requiresAuth: true },
+      component: () => import('@/views/apps/SelfOutbound.vue'),
+    },
+    {
+      path: 'nameplate-binding',
+      name: 'appsNameplateBinding',
+      meta: { title: '铭牌绑定', requiresAuth: true },
+      component: () => import('@/views/apps/NameplateBinding.vue'),
+    },
+  ],
 };

--- a/src/views/apps/InboundOrder.vue
+++ b/src/views/apps/InboundOrder.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="入库单" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/Layout.vue
+++ b/src/views/apps/Layout.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="apps-layout">
+    <router-view />
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.apps-layout {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+</style>

--- a/src/views/apps/MaterialMaintenance.vue
+++ b/src/views/apps/MaterialMaintenance.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="物料信息维护" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/MaterialTracking.vue
+++ b/src/views/apps/MaterialTracking.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="料况跟进" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/NameplateBinding.vue
+++ b/src/views/apps/NameplateBinding.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="铭牌绑定" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/OutsourcingQuotation.vue
+++ b/src/views/apps/OutsourcingQuotation.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="外协核价" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/PickingConfirmation.vue
+++ b/src/views/apps/PickingConfirmation.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="确认领料" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/SelfOutbound.vue
+++ b/src/views/apps/SelfOutbound.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="自助出库" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/ShipmentUpload.vue
+++ b/src/views/apps/ShipmentUpload.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="出货资料上传" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/SitePlanning.vue
+++ b/src/views/apps/SitePlanning.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="现场计划单" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/WireInspection.vue
+++ b/src/views/apps/WireInspection.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="线材质检" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/WorkReport.vue
+++ b/src/views/apps/WorkReport.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="工时汇报" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/WorkflowCenter.vue
+++ b/src/views/apps/WorkflowCenter.vue
@@ -1,0 +1,7 @@
+<template>
+  <AppPage title="流程中心" />
+</template>
+
+<script setup>
+import AppPage from './components/AppPage.vue';
+</script>

--- a/src/views/apps/components/AppPage.vue
+++ b/src/views/apps/components/AppPage.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="page app-page">
+    <ScrollAwareNavBar :title="title" fixed />
+    <div class="app-page__content">
+      <van-empty :description="description" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { toRefs } from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: '功能开发中，敬请期待',
+  },
+});
+
+const { title, description } = toRefs(props);
+</script>
+
+<style scoped>
+.app-page {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+
+.app-page__content {
+  min-height: calc(100vh - 96px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  box-sizing: border-box;
+}
+
+:deep(.van-empty__description) {
+  color: #5f6b7a;
+}
+</style>

--- a/src/views/apps/index.vue
+++ b/src/views/apps/index.vue
@@ -1,6 +1,71 @@
 <template>
-  <div class="page">
+  <div class="page apps">
     <ScrollAwareNavBar title="应用" fixed />
+    <div class="apps__content">
+      <van-grid
+        class="apps__grid"
+        :column-num="4"
+        :gutter="12"
+        clickable
+        :border="false"
+      >
+        <van-grid-item v-for="app in apps" :key="app.routeName" :to="{ name: app.routeName }">
+          <template #icon>
+            <img :src="app.icon" :alt="app.label" class="apps__icon" loading="lazy" />
+          </template>
+          <template #text>
+            <span class="apps__label">{{ app.label }}</span>
+          </template>
+        </van-grid-item>
+      </van-grid>
+    </div>
   </div>
 </template>
-<style lang="scss" scoped></style>
+
+<script setup>
+const apps = [
+  { label: '流程中心', icon: '/images/apps/流程中心.svg', routeName: 'appsWorkflowCenter' },
+  { label: '料况跟进', icon: '/images/apps/料况跟进.svg', routeName: 'appsMaterialTracking' },
+  { label: '入库单', icon: '/images/apps/入库单.svg', routeName: 'appsInboundOrder' },
+  { label: '现场计划单', icon: '/images/apps/现场计划单.svg', routeName: 'appsSitePlanning' },
+  { label: '工时汇报', icon: '/images/apps/工时汇报.svg', routeName: 'appsWorkReport' },
+  { label: '确认领料', icon: '/images/apps/确认领料.svg', routeName: 'appsPickingConfirmation' },
+  { label: '物料信息维护', icon: '/images/apps/物料信息维护.svg', routeName: 'appsMaterialMaintenance' },
+  { label: '线材质检', icon: '/images/apps/线材质检.svg', routeName: 'appsWireInspection' },
+  { label: '出货资料上传', icon: '/images/apps/出货资料上传.svg', routeName: 'appsShipmentUpload' },
+  { label: '外协核价', icon: '/images/apps/外协核价.svg', routeName: 'appsOutsourcingQuotation' },
+  { label: '自助出库', icon: '/images/apps/自助出库.svg', routeName: 'appsSelfOutbound' },
+  { label: '铭牌绑定', icon: '/images/apps/名牌绑定.svg', routeName: 'appsNameplateBinding' },
+];
+</script>
+
+<style lang="scss" scoped>
+.apps {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+
+.apps__content {
+  padding: 24px 16px;
+  padding-top: calc(72px + var(--van-safe-area-top, 0px));
+  box-sizing: border-box;
+}
+
+.apps__grid {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 12px 0;
+}
+
+.apps__icon {
+  width: 48px;
+  height: 48px;
+}
+
+.apps__label {
+  display: inline-block;
+  margin-top: 8px;
+  color: #323233;
+  font-size: 14px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add an applications grid with icons and routing on the apps tab
- register child routes and placeholder pages for each application entry

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f0aa1bbb80832782d8ab2609b5f69d