### PR TITLE
refactor: wrap wf-ui components with Vant adapters

### DIFF
--- a/src/components/wf-ui/adapter/UButton.vue
+++ b/src/components/wf-ui/adapter/UButton.vue
@@ -1,0 +1,52 @@
+<template>
+  <van-button
+    v-bind="{ ...$attrs, ...mappedProps }"
+    :style="buttonStyle"
+    @click="emit('click', $event)"
+  >
+    <slot></slot>
+  </van-button>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  type: {
+    type: String,
+    default: 'default',
+  },
+  size: {
+    type: String,
+    default: 'normal',
+  },
+  plain: {
+    type: Boolean,
+    default: false,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  customStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const emit = defineEmits(['click']);
+
+const mappedProps = computed(() => ({
+  type: props.type,
+  size: props.size,
+  plain: props.plain,
+  loading: props.loading,
+  disabled: props.disabled,
+}));
+
+const buttonStyle = computed(() => props.customStyle);
+</script>

--- a/src/components/wf-ui/adapter/UCard.vue
+++ b/src/components/wf-ui/adapter/UCard.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="u-card" :style="{ margin }">
+    <div class="u-card__head" :style="headStyle">
+      <slot name="head"></slot>
+    </div>
+    <div class="u-card__body" :style="bodyStyle">
+      <slot name="body"></slot>
+    </div>
+    <div v-if="hasFoot" class="u-card__foot" :style="footStyle">
+      <slot name="foot"></slot>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, useSlots } from 'vue';
+
+const { headStyle, bodyStyle, footStyle, margin } = defineProps({
+  headStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  bodyStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  footStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  margin: {
+    type: String,
+    default: '0',
+  },
+});
+
+const slots = useSlots();
+const hasFoot = computed(() => Boolean(slots.foot));
+</script>
+
+<style scoped>
+.u-card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.u-card__head,
+.u-card__body,
+.u-card__foot {
+  padding: 16px;
+}
+</style>

--- a/src/components/wf-ui/adapter/UCollapse.vue
+++ b/src/components/wf-ui/adapter/UCollapse.vue
@@ -1,0 +1,69 @@
+<template>
+  <van-collapse v-model="activeNames" :accordion="accordion">
+    <slot></slot>
+  </van-collapse>
+</template>
+
+<script setup>
+import { provide, reactive, ref, watch } from 'vue';
+
+const props = defineProps({
+  accordion: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const activeNames = ref(props.accordion ? '' : []);
+const items = reactive(new Map());
+
+function syncActiveNames() {
+  const opened = Array.from(items.entries())
+    .filter(([, value]) => value.open)
+    .map(([key]) => key);
+  if (props.accordion) {
+    activeNames.value = opened[0] ?? '';
+  } else {
+    activeNames.value = opened;
+  }
+}
+
+function registerItem(name, open) {
+  items.set(name, { open });
+  syncActiveNames();
+}
+
+function unregisterItem(name) {
+  if (items.has(name)) {
+    items.delete(name);
+    syncActiveNames();
+  }
+}
+
+function toggleItem(name, value) {
+  const item = items.get(name);
+  if (!item) return;
+  if (props.accordion && value) {
+    items.forEach((entry, key) => {
+      entry.open = key === name;
+    });
+  } else {
+    item.open = value;
+  }
+  syncActiveNames();
+}
+
+provide('uCollapseContext', {
+  registerItem,
+  unregisterItem,
+  toggleItem,
+  isAccordion: props.accordion,
+});
+
+watch(
+  () => props.accordion,
+  () => {
+    syncActiveNames();
+  }
+);
+</script>

--- a/src/components/wf-ui/adapter/UCollapseItem.vue
+++ b/src/components/wf-ui/adapter/UCollapseItem.vue
@@ -1,0 +1,62 @@
+<template>
+  <van-collapse-item :name="itemName" :disabled="disabled">
+    <template #title>
+      <div class="u-collapse-item__title" :style="headStyle">
+        <slot name="title">{{ title }}</slot>
+      </div>
+    </template>
+    <slot></slot>
+  </van-collapse-item>
+</template>
+
+<script setup>
+import { inject, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: '',
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  open: {
+    type: Boolean,
+    default: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  headStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const collapse = inject('uCollapseContext');
+const itemName = ref(props.name || `u-collapse-item-${Math.random().toString(36).slice(2, 8)}`);
+
+onMounted(() => {
+  collapse?.registerItem(itemName.value, props.open);
+});
+
+onBeforeUnmount(() => {
+  collapse?.unregisterItem(itemName.value);
+});
+
+watch(
+  () => props.open,
+  (value) => {
+    collapse?.toggleItem(itemName.value, value);
+  }
+);
+</script>
+
+<style scoped>
+.u-collapse-item__title {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/src/components/wf-ui/adapter/UForm.vue
+++ b/src/components/wf-ui/adapter/UForm.vue
@@ -1,0 +1,126 @@
+<template>
+  <form class="u-form" @submit.prevent="handleSubmit">
+    <slot></slot>
+  </form>
+</template>
+
+<script setup>
+import { reactive, watch } from 'vue';
+import { deepClone } from '../util/index.js';
+
+const props = defineProps({
+  model: {
+    type: Object,
+    default: () => ({}),
+  },
+  errorType: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(['submit']);
+
+const rules = reactive({});
+let initialModel = deepClone(props.model || {});
+
+watch(
+  () => props.model,
+  (model) => {
+    initialModel = deepClone(model || {});
+  },
+  { deep: true }
+);
+
+function setRules(newRules = {}) {
+  Object.keys(rules).forEach((key) => {
+    delete rules[key];
+  });
+  Object.assign(rules, newRules);
+}
+
+function isEmptyValue(value) {
+  if (Array.isArray(value)) return value.length === 0;
+  return value === undefined || value === null || value === '';
+}
+
+async function validateRule(rule, value) {
+  if (rule.required && isEmptyValue(value)) {
+    return { valid: false, message: rule.message || '必填项不能为空' };
+  }
+  if (rule.pattern && !isEmptyValue(value)) {
+    const pattern = rule.pattern instanceof RegExp ? rule.pattern : new RegExp(rule.pattern);
+    if (!pattern.test(String(value))) {
+      return { valid: false, message: rule.message || '格式不正确' };
+    }
+  }
+  if (typeof rule.validator === 'function') {
+    const result = rule.validator(value, rule);
+    if (result && typeof result.then === 'function') {
+      const resolved = await result;
+      if (resolved === false) {
+        return { valid: false, message: rule.message || '校验失败' };
+      }
+      if (typeof resolved === 'string') {
+        return { valid: false, message: resolved };
+      }
+    } else if (result === false) {
+      return { valid: false, message: rule.message || '校验失败' };
+    } else if (typeof result === 'string') {
+      return { valid: false, message: result };
+    }
+  }
+  return { valid: true };
+}
+
+async function runValidation() {
+  const errors = [];
+  for (const [prop, propRules] of Object.entries(rules)) {
+    if (!Array.isArray(propRules) || propRules.length === 0) continue;
+    const value = props.model ? props.model[prop] : undefined;
+    for (const rule of propRules) {
+      const result = await validateRule(rule, value);
+      if (!result.valid) {
+        errors.push({ prop, message: result.message });
+        break;
+      }
+    }
+  }
+  return errors;
+}
+
+async function validate(callback) {
+  const errors = await runValidation();
+  const valid = errors.length === 0;
+  if (callback) {
+    callback(valid, errors);
+  }
+  return valid;
+}
+
+function resetFields() {
+  if (!props.model) return;
+  Object.keys(initialModel).forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(props.model, key)) {
+      // eslint-disable-next-line vue/no-mutating-props
+      props.model[key] = deepClone(initialModel[key]);
+    }
+  });
+}
+
+function handleSubmit() {
+  emit('submit', props.model);
+}
+
+function submit() {
+  handleSubmit();
+}
+
+defineExpose({ setRules, validate, resetFields, submit });
+</script>
+
+<style scoped>
+.u-form {
+  width: 100%;
+}
+</style>

--- a/src/components/wf-ui/adapter/UFormItem.vue
+++ b/src/components/wf-ui/adapter/UFormItem.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="u-form-item" :class="[`label-${labelPosition}`]">
+    <label v-if="label" class="u-form-item__label" :style="labelStyles">
+      <span v-if="required" class="u-form-item__required">*</span>{{ label }}
+    </label>
+    <div class="u-form-item__content">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  label: {
+    type: String,
+    default: '',
+  },
+  labelWidth: {
+    type: [String, Number],
+    default: undefined,
+  },
+  labelPosition: {
+    type: String,
+    default: 'left',
+  },
+  required: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const labelStyles = computed(() => {
+  if (!props.labelWidth) return undefined;
+  const width = typeof props.labelWidth === 'number' ? `${props.labelWidth}px` : props.labelWidth;
+  return { width };
+});
+</script>
+
+<style scoped>
+.u-form-item {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 16px;
+}
+
+.u-form-item.label-top {
+  flex-direction: column;
+}
+
+.u-form-item__label {
+  font-size: 14px;
+  color: #323233;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.u-form-item.label-left .u-form-item__label {
+  margin-bottom: 0;
+  margin-right: 16px;
+  justify-content: flex-end;
+}
+
+.u-form-item__required {
+  color: #ee0a24;
+  margin-right: 4px;
+}
+
+.u-form-item__content {
+  flex: 1;
+}
+</style>

--- a/src/components/wf-ui/adapter/ULoadmore.vue
+++ b/src/components/wf-ui/adapter/ULoadmore.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="u-loadmore" :style="{ marginBottom }">
+    <template v-if="status === 'loading'">
+      <van-loading size="24px">加载中...</van-loading>
+    </template>
+    <template v-else-if="status === 'nomore'">
+      <span class="u-loadmore__text">没有更多了</span>
+    </template>
+    <template v-else>
+      <van-button type="primary" size="small" @click="emit('loadmore')">加载更多</van-button>
+    </template>
+  </div>
+</template>
+
+<script setup>
+const { status, marginBottom } = defineProps({
+  status: {
+    type: String,
+    default: 'loadmore',
+  },
+  marginBottom: {
+    type: [Number, String],
+    default: '0',
+  },
+});
+
+const emit = defineEmits(['loadmore']);
+</script>
+
+<style scoped>
+.u-loadmore {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 12px 0;
+  color: #969799;
+  font-size: 14px;
+}
+
+.u-loadmore__text {
+  color: #969799;
+}
+</style>

--- a/src/components/wf-ui/adapter/UNumberBox.vue
+++ b/src/components/wf-ui/adapter/UNumberBox.vue
@@ -1,0 +1,50 @@
+<template>
+  <van-stepper
+    v-model="currentValue"
+    :min="min"
+    :max="max"
+    :step="step"
+    :integer="positiveInteger"
+    :disabled="disabled"
+    :show-plus="true"
+    :show-minus="true"
+  />
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: [Number, String],
+    default: 0,
+  },
+  min: {
+    type: [Number, String],
+    default: 0,
+  },
+  max: {
+    type: [Number, String],
+    default: Number.MAX_SAFE_INTEGER,
+  },
+  step: {
+    type: [Number, String],
+    default: 1,
+  },
+  positiveInteger: {
+    type: Boolean,
+    default: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const currentValue = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+</script>

--- a/src/components/wf-ui/adapter/UPicker.vue
+++ b/src/components/wf-ui/adapter/UPicker.vue
@@ -1,0 +1,90 @@
+<template>
+  <UPopup v-model="visible" position="bottom" :style="{ borderRadius: '12px 12px 0 0' }">
+    <van-time-picker
+      v-model="timeValues"
+      :columns-type="columnsType"
+      :title="title"
+      :cancel-button-text="cancelText"
+      @confirm="onConfirm"
+      @cancel="onCancel"
+    />
+  </UPopup>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import UPopup from './UPopup.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  mode: {
+    type: String,
+    default: 'time',
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  cancelText: {
+    type: String,
+    default: '取消',
+  },
+  defaultTime: {
+    type: String,
+    default: '00:00:00',
+  },
+  params: {
+    type: Object,
+    default: () => ({ hour: true, minute: true, second: true }),
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'confirm', 'cancel']);
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+
+const columnsType = computed(() => {
+  if (props.mode !== 'time') return ['hour', 'minute', 'second'];
+  const result = [];
+  if (props.params?.hour !== false) result.push('hour');
+  if (props.params?.minute !== false) result.push('minute');
+  if (props.params?.second !== false) result.push('second');
+  return result.length ? result : ['hour', 'minute', 'second'];
+});
+
+const timeValues = ref(['00', '00', '00']);
+
+function parseTime(time) {
+  if (!time) return ['00', '00', '00'];
+  const [hour = '00', minute = '00', second = '00'] = time.split(':');
+  return [hour, minute, second];
+}
+
+watch(
+  () => props.defaultTime,
+  (value) => {
+    timeValues.value = parseTime(value);
+  },
+  { immediate: true }
+);
+
+function onConfirm(payload) {
+  const values = Array.isArray(payload)
+    ? payload
+    : payload?.selectedValues || payload?.values || timeValues.value;
+  const [hour = '00', minute = '00', second = '00'] = values;
+  emit('confirm', { hour, minute, second });
+  emit('update:modelValue', false);
+}
+
+function onCancel() {
+  emit('cancel');
+  emit('update:modelValue', false);
+}
+</script>

--- a/src/components/wf-ui/adapter/UPopup.vue
+++ b/src/components/wf-ui/adapter/UPopup.vue
@@ -1,0 +1,30 @@
+<template>
+  <van-popup
+    v-model:show="show"
+    v-bind="$attrs"
+    @open="$emit('open')"
+    @close="$emit('close')"
+    @opened="$emit('opened')"
+    @closed="$emit('closed')"
+  >
+    <slot></slot>
+  </van-popup>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'open', 'close', 'opened', 'closed']);
+
+const show = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+</script>

--- a/src/components/wf-ui/adapter/USelect.vue
+++ b/src/components/wf-ui/adapter/USelect.vue
@@ -1,0 +1,91 @@
+<template>
+  <UPopup v-model="visible" position="bottom" :style="{ borderRadius: '12px 12px 0 0' }">
+    <van-picker
+      :title="title"
+      :columns="columns"
+      :columns-field-names="fieldNames"
+      :loading="loading"
+      @confirm="handleConfirm"
+      @cancel="handleCancel"
+    />
+  </UPopup>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import UPopup from './UPopup.vue';
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  list: {
+    type: Array,
+    default: () => [],
+  },
+  mode: {
+    type: String,
+    default: 'single-column',
+  },
+  labelName: {
+    type: String,
+    default: 'label',
+  },
+  valueName: {
+    type: String,
+    default: 'value',
+  },
+  childName: {
+    type: String,
+    default: 'children',
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  loading: Boolean,
+});
+
+const emit = defineEmits(['update:modelValue', 'confirm', 'cancel']);
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+
+const fieldNames = computed(() => ({
+  text: props.labelName,
+  value: props.valueName,
+  children: props.childName,
+}));
+
+const columns = computed(() => {
+  if (props.mode === 'single-column') {
+    return props.list;
+  }
+  return [{ values: props.list }];
+});
+
+function normalizeOption(option) {
+  const label = option?.[props.labelName] ?? '';
+  const value = option?.[props.valueName];
+  return { label, value };
+}
+
+function handleConfirm(values) {
+  const selected = Array.isArray(values)
+    ? values
+    : values?.selectedOptions || values?.selectedValues || [];
+  const options = Array.isArray(selected)
+    ? selected.map((item) => normalizeOption(item))
+    : [normalizeOption(values)];
+  emit('confirm', options);
+  emit('update:modelValue', false);
+}
+
+function handleCancel() {
+  emit('cancel');
+  emit('update:modelValue', false);
+}
+</script>

--- a/src/components/wf-ui/adapter/UToast.vue
+++ b/src/components/wf-ui/adapter/UToast.vue
@@ -1,0 +1,21 @@
+<template>
+  <div></div>
+</template>
+
+<script setup>
+import { Toast } from 'vant';
+
+function show(options = {}) {
+  const { title, type, duration = 2000 } = options;
+  const mapper = {
+    success: Toast.success,
+    error: Toast.fail,
+    warning: Toast.fail,
+    loading: Toast.loading,
+  };
+  const handler = mapper[type] || Toast.show;
+  handler({ message: title || '', duration, forbidClick: type === 'loading' });
+}
+
+defineExpose({ show });
+</script>

--- a/src/components/wf-ui/adapter/registerVantAdapters.js
+++ b/src/components/wf-ui/adapter/registerVantAdapters.js
@@ -1,0 +1,99 @@
+import {
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Collapse,
+  CollapseItem,
+  Empty,
+  Field,
+  Icon,
+  Loading,
+  Picker,
+  Popup,
+  Radio,
+  RadioGroup,
+  Rate,
+  Search,
+  Slider,
+  Stepper,
+  Switch,
+  TimePicker,
+} from 'vant';
+import UPopup from './UPopup.vue';
+import USelect from './USelect.vue';
+import ULoadmore from './ULoadmore.vue';
+import UForm from './UForm.vue';
+import UFormItem from './UFormItem.vue';
+import UToast from './UToast.vue';
+import UNumberBox from './UNumberBox.vue';
+import UButton from './UButton.vue';
+import UCard from './UCard.vue';
+import UCollapse from './UCollapse.vue';
+import UCollapseItem from './UCollapseItem.vue';
+import UPicker from './UPicker.vue';
+
+const aliasComponents = [
+  ['u-field', Field],
+  ['u-input', Field],
+  ['u-icon', Icon],
+  ['u-search', Search],
+  ['u-switch', Switch],
+  ['u-radio', Radio],
+  ['u-radio-group', RadioGroup],
+  ['u-checkbox', Checkbox],
+  ['u-checkbox-group', CheckboxGroup],
+  ['u-slider', Slider],
+  ['u-rate', Rate],
+  ['u-empty', Empty],
+];
+
+const customComponents = [
+  ['u-popup', UPopup],
+  ['u-select', USelect],
+  ['u-loadmore', ULoadmore],
+  ['u-form', UForm],
+  ['u-form-item', UFormItem],
+  ['u-toast', UToast],
+  ['u-number-box', UNumberBox],
+  ['u-button', UButton],
+  ['u-card', UCard],
+  ['u-collapse', UCollapse],
+  ['u-collapse-item', UCollapseItem],
+  ['u-picker', UPicker],
+];
+
+const baseComponents = [
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Collapse,
+  CollapseItem,
+  Empty,
+  Field,
+  Icon,
+  Loading,
+  Picker,
+  Popup,
+  Radio,
+  RadioGroup,
+  Rate,
+  Search,
+  Slider,
+  Stepper,
+  Switch,
+  TimePicker,
+];
+
+export function registerVantAdapters(app) {
+  aliasComponents.forEach(([name, component]) => {
+    app.component(name, component);
+  });
+
+  customComponents.forEach(([name, component]) => {
+    app.component(name, component);
+  });
+
+  baseComponents.forEach((component) => {
+    app.component(component.name, component);
+  });
+}

--- a/src/components/wf-ui/components/wf-cascader/components/cascader.vue
+++ b/src/components/wf-ui/components/wf-cascader/components/cascader.vue
@@ -1,591 +1,564 @@
 <template>
-	<view class="wf-cascade-selection">
-		<view class="wf-cascade-title" v-if="title">{{ title }}</view>
-		<scroll-view
-			scroll-x
-			scroll-with-animation
-			:scroll-into-view="scrollViewId"
-			:style="{ backgroundColor: headerBgColor }"
-			class="wf-bottom-line"
-			:class="{ 'wf-btm-none': !headerLine }"
-		>
-			<view class="wf-selection-header" :style="{ height: tabsHeight, backgroundColor: backgroundColor }">
-				<view
-					class="wf-header-item"
-					:class="{ 'wf-font-bold': index === currentTab && bold }"
-					:style="{ color: index === currentTab ? activeColor : color, fontSize: size + 'rpx' }"
-					:id="`id_${index}`"
-					@tap.stop="swichNav"
-					:data-current="index"
-					v-for="(item, index) in selectedArr"
-					:key="index"
-				>
-					{{ item[labelKey] }}
-					<view class="wf-active-line" :style="{ backgroundColor: lineColor }" v-if="index === currentTab && showLine"></view>
-				</view>
-			</view>
-		</scroll-view>
-		<swiper
-			class="wf-selection-list"
-			:current="currentTab"
-			duration="200"
-			@change="switchTab"
-			:style="{ height: height, backgroundColor: backgroundColor }"
-		>
-			<swiper-item v-for="(item, index) in selectedArr" :key="index">
-				<scroll-view scroll-y :scroll-into-view="item.scrollViewId" class="wf-selection-item" :style="{ height: height }">
-					<view class="wf-first-item" :style="{ height: firstItemTop }"></view>
-					<view
-						class="wf-selection-cell"
-						:style="{ padding: padding, backgroundColor: backgroundColor }"
-						:id="`id_${subIndex}`"
-						v-for="(subItem, subIndex) in item.list"
-						:key="subIndex"
-						@tap="change(index, subIndex, subItem)"
-					>
-						<icon
-							type="success_no_circle"
-							v-if="item.index === subIndex"
-							:color="checkMarkColor"
-							:size="checkMarkSize"
-							class="wf-icon-success"
-						></icon>
-						<image
-							:src="subItem.src"
-							v-if="subItem.src"
-							class="wf-cell-img"
-							:style="{ width: imgWidth, height: imgHeight, borderRadius: radius }"
-						></image>
-						<view
-							class="wf-cell-title"
-							:class="{ 'wf-font-bold': item.index === subIndex && textBold, 'wf-flex-shrink': nowrap }"
-							:style="{ color: item.index === subIndex ? textActiveColor : textColor, fontSize: textSize + 'rpx' }"
-						>
-							{{ subItem[labelKey] }}
-						</view>
-						<view
-							class="wf-cell-sub_title"
-							:style="{ color: subTextColor, fontSize: subTextSize + 'rpx' }"
-							v-if="subItem[descKey]"
-						>
-							{{ subItem[descKey] }}
-						</view>
-					</view>
-				</scroll-view>
-			</swiper-item>
-		</swiper>
-	</view>
+  <div class="wf-cascade-selection">
+    <div v-if="title" class="wf-cascade-title">{{ title }}</div>
+    <div
+      class="wf-bottom-line wf-scroll-x"
+      :class="{ 'wf-btm-none': !headerLine }"
+      ref="headerScroll"
+      :style="{ backgroundColor: headerBgColor }"
+    >
+      <div class="wf-selection-header" :style="{ height: toPx(tabsHeight), backgroundColor: backgroundColor }">
+        <div
+          v-for="(item, index) in selectedArr"
+          :key="index"
+          ref="headerItems"
+          class="wf-header-item"
+          :class="{ 'wf-font-bold': index === currentTab && bold }"
+          :style="{ color: index === currentTab ? activeColor : color, fontSize: toPx(size) }"
+          @click.stop="swichNav(index)"
+        >
+          {{ item[labelKey] }}
+          <div
+            v-if="index === currentTab && showLine"
+            class="wf-active-line"
+            :style="{ backgroundColor: lineColor }"
+          ></div>
+        </div>
+      </div>
+    </div>
+    <div class="wf-selection-list" :style="{ height: toPx(height), backgroundColor: backgroundColor }">
+      <div
+        v-for="(item, index) in selectedArr"
+        :key="index"
+        v-show="index === currentTab"
+        class="wf-selection-panel"
+      >
+        <div ref="listContainers" class="wf-selection-item" :style="{ height: toPx(height) }">
+          <div class="wf-first-item" :style="{ height: toPx(firstItemTop) }"></div>
+          <div
+            v-for="(subItem, subIndex) in item.list"
+            :key="subIndex"
+            class="wf-selection-cell"
+            :style="{ padding: toPx(padding), backgroundColor: backgroundColor }"
+            :data-scroll-index="subIndex"
+            @click="change(index, subIndex, subItem)"
+          >
+            <van-icon
+              v-if="item.index === subIndex"
+              name="success"
+              :color="checkMarkColor"
+              class="wf-icon-success"
+              :style="{ fontSize: toPx(checkMarkSize) }"
+            />
+            <img
+              v-if="subItem.src"
+              :src="subItem.src"
+              class="wf-cell-img"
+              :style="{ width: toPx(imgWidth), height: toPx(imgHeight), borderRadius: toPx(radius) }"
+              alt=""
+            />
+            <div
+              class="wf-cell-title"
+              :class="{ 'wf-font-bold': item.index === subIndex && textBold, 'wf-flex-shrink': nowrap }"
+              :style="{ color: item.index === subIndex ? textActiveColor : textColor, fontSize: toPx(textSize) }"
+            >
+              {{ subItem[labelKey] }}
+            </div>
+            <div
+              v-if="subItem[descKey]"
+              class="wf-cell-sub_title"
+              :style="{ color: subTextColor, fontSize: toPx(subTextSize) }"
+            >
+              {{ subItem[descKey] }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
 import { DIC_PROPS } from '../../../util/variable.js'
+
 export default {
-	name: 'wfCascade',
-	props: {
-		title: String,
-		props: {
-			type: Object,
-			default: () => DIC_PROPS
-		},
-		multiple: {
-			type: Boolean,
-			default: false
-		},
-		/**
-			 * 如果下一级是请求返回，则为第一级数据，否则所有数据
-			 * 数据格式
-			  [{
-				  src: "",
-				  text: "",
-				  subText: "",
-				  value: 0,
-				  children:[{
-					  text: "",
-					  subText: "",
-					  value: 0,
-					  children:[]
-			   }]
-			  }]
-			 * */
-		itemList: {
-			type: Array,
-			default: () => {
-				return []
-			}
-		},
-		/*
-		   初始化默认选中数据
-		   [{
-			text: "",//选中text
-			subText: '',//选中subText
-			value: '',//选中value
-			src: '', //选中src，没有则传空或不传
-			index: 0, //选中数据在当前layer索引
-			list: [{src: "", text: "", subText: "", value: 101}] //所有layer数据集合
-		  }];
+  name: 'WfCascade',
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+    props: {
+      type: Object,
+      default: () => DIC_PROPS,
+    },
+    multiple: {
+      type: Boolean,
+      default: false,
+    },
+    itemList: {
+      type: Array,
+      default: () => [],
+    },
+    defaultItemList: {
+      type: Array,
+      default: () => [],
+    },
+    headerLine: {
+      type: Boolean,
+      default: true,
+    },
+    headerBgColor: {
+      type: String,
+      default: '#FFFFFF',
+    },
+    tabsHeight: {
+      type: String,
+      default: '88rpx',
+    },
+    text: {
+      type: String,
+      default: '请选择',
+    },
+    size: {
+      type: Number,
+      default: 28,
+    },
+    color: {
+      type: String,
+      default: '#555',
+    },
+    activeColor: {
+      type: String,
+      default: '#5677fc',
+    },
+    bold: {
+      type: Boolean,
+      default: true,
+    },
+    showLine: {
+      type: Boolean,
+      default: true,
+    },
+    lineColor: {
+      type: String,
+      default: '#5677fc',
+    },
+    checkMarkSize: {
+      type: Number,
+      default: 15,
+    },
+    checkMarkColor: {
+      type: String,
+      default: '#5677fc',
+    },
+    imgWidth: {
+      type: String,
+      default: '40rpx',
+    },
+    imgHeight: {
+      type: String,
+      default: '40rpx',
+    },
+    radius: {
+      type: String,
+      default: '50%',
+    },
+    textColor: {
+      type: String,
+      default: '#333',
+    },
+    textActiveColor: {
+      type: String,
+      default: '#333',
+    },
+    textBold: {
+      type: Boolean,
+      default: true,
+    },
+    textSize: {
+      type: Number,
+      default: 28,
+    },
+    nowrap: {
+      type: Boolean,
+      default: false,
+    },
+    subTextColor: {
+      type: String,
+      default: '#999',
+    },
+    subTextSize: {
+      type: Number,
+      default: 24,
+    },
+    padding: {
+      type: String,
+      default: '20rpx 30rpx',
+    },
+    firstItemTop: {
+      type: String,
+      default: '20rpx',
+    },
+    height: {
+      type: String,
+      default: '300px',
+    },
+    backgroundColor: {
+      type: String,
+      default: '#FFFFFF',
+    },
+    request: {
+      type: Boolean,
+      default: false,
+    },
+    receiveData: {
+      type: Array,
+      default: () => [],
+    },
+    reset: {
+      type: [Number, String],
+      default: 0,
+    },
+  },
+  data() {
+    return {
+      currentTab: 0,
+      selectedArr: [],
+    }
+  },
+  computed: {
+    valueKey() {
+      return this.props.value || DIC_PROPS.value
+    },
+    labelKey() {
+      return this.props.label || DIC_PROPS.label
+    },
+    childrenKey() {
+      return this.props.children || DIC_PROPS.children
+    },
+    descKey() {
+      return this.props.desc || DIC_PROPS.desc
+    },
+  },
+  emits: ['change', 'complete'],
+  watch: {
+    itemList(val) {
+      this.initData(val, -1)
+    },
+    receiveData(val) {
+      this.subLevelData(val, this.currentTab)
+    },
+    reset() {
+      this.initData(this.itemList, -1)
+    },
+    defaultItemList(val) {
+      this.setDefaultData(val)
+    },
+    currentTab() {
+      this.checkCor()
+    },
+    selectedArr: {
+      handler() {
+        this.checkCor()
+      },
+      deep: true,
+    },
+  },
+  created() {
+    this.setDefaultData(this.defaultItemList)
+  },
+  methods: {
+    toPx(value) {
+      if (typeof value === 'number') return `${value}px`
+      if (typeof value === 'string') {
+        return value.replace(/rpx/g, 'px')
+      }
+      return value
+    },
+    scrollToHeader(index) {
+      const refs = this.$refs.headerItems
+      if (!refs) return
+      const elements = Array.isArray(refs) ? refs : [refs]
+      const el = elements[index]
+      if (el && el.scrollIntoView) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+      }
+    },
+    scrollToList(layerIndex, subIndex) {
+      const refs = this.$refs.listContainers
+      if (!refs) return
+      const containers = Array.isArray(refs) ? refs : [refs]
+      const container = containers[layerIndex]
+      if (!container) return
+      if (subIndex == null || subIndex < 0) {
+        container.scrollTop = 0
+        return
+      }
+      const target = container.querySelector(`[data-scroll-index="${subIndex}"]`)
+      if (target && target.scrollIntoView) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      }
+    },
+    setDefaultData(val) {
+      const defaultItemList = val || []
+      if (defaultItemList.length > 0) {
+        this.selectedArr = defaultItemList
+        this.currentTab = defaultItemList.length - 1
+      } else {
+        this.initData(this.itemList, -1)
+      }
+    },
+    initData(data, layer) {
+      if (!data || data.length === 0) return
+      if (this.request) {
+        this.subLevelData(data, layer)
+      } else {
+        const selectedValue = this.selectedValue || {}
+        if (selectedValue.type) {
+          this.setDefaultData(selectedValue)
+        } else {
+          this.subLevelData(this.getItemList(layer, -1), layer)
+        }
+      }
+    },
+    removeChildren(data) {
+      return (data || []).map(item => {
+        const clone = { ...item }
+        delete clone[this.childrenKey]
+        return clone
+      })
+    },
+    getItemList(layer, index) {
+      let list = []
+      const arr = JSON.parse(JSON.stringify(this.itemList))
+      if (layer === -1) {
+        list = this.removeChildren(arr)
+      } else {
+        let value = (this.selectedArr[0] && this.selectedArr[0].index)
+        value = value === -1 ? index : value
+        const firstLevel = arr[value] || {}
+        list = firstLevel[this.childrenKey] || []
+        if (layer > 0) {
+          for (let i = 1; i < layer + 1; i++) {
+            const current = this.selectedArr[i] || {}
+            const val = layer === i ? index : current.index
+            const levelItem = list[val] || {}
+            list = levelItem[this.childrenKey] || []
+            if (!list || list.length === 0) break
+          }
+        }
+        list = this.removeChildren(list)
+      }
+      return list
+    },
+    swichNav(index) {
+      if (this.currentTab !== index) {
+        this.currentTab = index
+      }
+    },
+    checkCor() {
+      const item = this.selectedArr[this.currentTab]
+      if (!item) return
+      this.$nextTick(() => {
+        this.scrollToHeader(this.currentTab)
+        this.scrollToList(this.currentTab, item.index)
+      })
+    },
+    change(index, subIndex, subItem) {
+      const item = this.selectedArr[index]
+      if (!item || item.index === subIndex) return
+      this.selectedArr.splice(index + 1)
+      item.index = subIndex
+      item[this.labelKey] = subItem[this.labelKey]
+      item[this.valueKey] = subItem[this.valueKey]
+      item[this.descKey] = subItem[this.descKey] || ''
+      item.src = subItem.src || ''
 
-		   */
-		defaultItemList: {
-			type: Array,
-			value: []
-		},
-		//是否显示header底部细线
-		headerLine: {
-			type: Boolean,
-			default: true
-		},
-		//header背景颜色
-		headerBgColor: {
-			type: String,
-			default: '#FFFFFF'
-		},
-		//顶部标签栏高度
-		tabsHeight: {
-			type: String,
-			default: '88rpx'
-		},
-		//默认显示文字
-		text: {
-			type: String,
-			default: '请选择'
-		},
-		//tabs 文字大小
-		size: {
-			type: Number,
-			default: 28
-		},
-		//tabs 文字颜色
-		color: {
-			type: String,
-			default: '#555'
-		},
-		//选中颜色
-		activeColor: {
-			type: String,
-			default: '#5677fc'
-		},
-		//选中后文字加粗
-		bold: {
-			type: Boolean,
-			default: true
-		},
-		//选中后是否显示底部线条
-		showLine: {
-			type: Boolean,
-			default: true
-		},
-		//线条颜色
-		lineColor: {
-			type: String,
-			default: '#5677fc'
-		},
-		//icon 大小
-		checkMarkSize: {
-			type: Number,
-			default: 15
-		},
-		//icon 颜色
-		checkMarkColor: {
-			type: String,
-			default: '#5677fc'
-		},
-		//item 图片宽度
-		imgWidth: {
-			type: String,
-			default: '40rpx'
-		},
-		//item 图片高度
-		imgHeight: {
-			type: String,
-			default: '40rpx'
-		},
-		//图片圆角
-		radius: {
-			type: String,
-			default: '50%'
-		},
-		//item text颜色
-		textColor: {
-			type: String,
-			default: '#333'
-		},
-		textActiveColor: {
-			type: String,
-			default: '#333'
-		},
-		//选中后字体是否加粗
-		textBold: {
-			type: Boolean,
-			default: true
-		},
-		//item text字体大小
-		textSize: {
-			type: Number,
-			default: 28
-		},
-		//text 是否不换行
-		nowrap: {
-			type: Boolean,
-			default: false
-		},
-		//item subText颜色
-		subTextColor: {
-			type: String,
-			default: '#999'
-		},
-		//item subText字体大小
-		subTextSize: {
-			type: Number,
-			default: 24
-		},
-		// item padding
-		padding: {
-			type: String,
-			default: '20rpx 30rpx'
-		},
-		//占位高度，第一条数据距离顶部距离
-		firstItemTop: {
-			type: String,
-			default: '20rpx'
-		},
-		//swiper 高度
-		height: {
-			type: String,
-			default: '300px'
-		},
-		//item  swiper 内容部分背景颜色
-		backgroundColor: {
-			type: String,
-			default: '#FFFFFF'
-		},
-		//子集数据是否请求返回（默认false，一次性返回所有数据）
-		request: {
-			type: Boolean,
-			default: false
-		},
-		//子级数据（当有改变时，默认当前选中项新增子级数据，request=true时生效）
-		receiveData: {
-			type: Array,
-			default: () => {
-				return []
-			}
-		},
-		//改变值则重置数据
-		reset: {
-			type: [Number, String],
-			default: 0
-		}
-	},
-	watch: {
-		itemList(val) {
-			this.initData(val, -1)
-		},
-		receiveData(val) {
-			this.subLevelData(val, this.currentTab)
-		},
-		reset() {
-			this.initData(this.itemList, -1)
-		},
-		defaultItemList(val) {
-			this.setDefaultData(val)
-		}
-	},
-	created() {
-		this.setDefaultData(this.defaultItemList)
-	},
-	computed: {
-		valueKey() {
-			return this.props.value || DIC_PROPS.value
-		},
-		labelKey() {
-			return this.props.label || DIC_PROPS.label
-		},
-		childrenKey() {
-			return this.props.children || DIC_PROPS.children
-		},
-		descKey() {
-			return this.props.desc || DIC_PROPS.desc
-		}
-	},
-	data() {
-		return {
-			currentTab: 0,
-			//tab栏scrollview滚动的位置
-			scrollViewId: 'id__1',
-			selectedArr: []
-		}
-	},
-	methods: {
-		setDefaultData(val) {
-			let defaultItemList = val || []
-			if (defaultItemList.length > 0) {
-				defaultItemList.map(item => {
-					item.scrollViewId = `id_${item.index}`
-				})
-				this.selectedArr = defaultItemList
-				this.currentTab = defaultItemList.length - 1
-				this.$nextTick(() => {
-					this.checkCor()
-				})
-			} else {
-				this.initData(this.itemList, -1)
-			}
-		},
-		initData(data, layer) {
-			if (!data || data.length === 0) return
-			if (this.request) {
-				//第一级数据
-				this.subLevelData(data, layer)
-			} else {
-				let selectedValue = this.selectedValue || {}
-				if (selectedValue.type) {
-					this.setDefaultData(selectedValue)
-				} else {
-					this.subLevelData(this.getItemList(layer, -1), layer)
-				}
-			}
-		},
-		removeChildren(data) {
-			let list = data.map(item => {
-				delete item[this.childrenKey]
-				return item
-			})
-			return list
-		},
-		getItemList(layer, index) {
-			let list = []
-			let arr = JSON.parse(JSON.stringify(this.itemList))
-			if (layer == -1) {
-				list = this.removeChildren(arr)
-			} else {
-				let value = this.selectedArr[0].index
-				value = value == -1 ? index : value
-				list = arr[value][this.childrenKey] || []
-				if (layer > 0) {
-					for (let i = 1; i < layer + 1; i++) {
-						let val = layer === i ? index : this.selectedArr[i].index
-						list = list[val][this.childrenKey] || []
-						if (list.length === 0) break
-					}
-				}
-				list = this.removeChildren(list)
-			}
-			return list
-		},
-		//滚动切换
-		switchTab(e) {
-			this.currentTab = e.detail.current
-			this.checkCor()
-		},
-		//点击标题切换当
-		swichNav(e) {
-			let cur = e.currentTarget.dataset.current
-			if (this.currentTab != cur) {
-				this.currentTab = cur
-			}
-		},
-		checkCor() {
-			let item = this.selectedArr[this.currentTab]
-			item.scrollViewId = 'id__1'
-			this.$nextTick(() => {
-				setTimeout(() => {
-					let val = item.index < 2 ? 0 : Number(item.index - 2)
-					item.scrollViewId = `id_${val}`
-				}, 2)
-			})
+      this.$emit('change', {
+        layer: index,
+        subIndex,
+        ...subItem,
+      })
 
-			if (this.currentTab > 1) {
-				this.scrollViewId = `id_${this.currentTab - 1}`
-			} else {
-				this.scrollViewId = `id_0`
-			}
-		},
-		change(index, subIndex, subItem) {
-			let item = this.selectedArr[index]
-			if (item.index == subIndex) return
-			this.selectedArr.length = index + 1
-			item.index = subIndex
-			item[this.labelKey] = subItem[this.labelKey]
-			item[this.valueKey] = subItem[this.valueKey]
-			item[this.descKey] = subItem[this.descKey] || ''
-			item.src = subItem.src || ''
-
-			this.$emit('change', {
-				layer: index,
-				subIndex: subIndex, //layer=> Array index
-				...subItem
-			})
-
-			if (!this.request) {
-				let data = this.getItemList(index, subIndex)
-				this.subLevelData(data, index)
-			}
-		},
-		//新增子级数据时处理
-		subLevelData(data, layer) {
-			if (!data || data.length === 0) {
-				if (layer == -1) return
-				//完成选择
-				let result = JSON.parse(JSON.stringify(this.selectedArr))
-				let lastItem = result[result.length - 1] || {}
-				let text = []
-				result.map(item => {
-					text.push(item[this.labelKey])
-					delete item['list']
-					//delete item['index'];
-					delete item['scrollViewId']
-					return item
-				})
-				this.$emit('complete', {
-					result: result,
-					[this.valueKey]: lastItem[this.valueKey],
-					[this.labelKey]: text.join('/'),
-					[this.descKey]: lastItem[this.descKey],
-					src: lastItem.src
-				})
-			} else {
-				//重置数据（ >layer层级）
-				let item = [
-					{
-						[this.labelKey]: this.text,
-						[this.descKey]: '',
-						[this.valueKey]: '',
-						src: '',
-						index: -1,
-						scrollViewId: 'id__1',
-						list: data
-					}
-				]
-				if (layer == -1) {
-					this.selectedArr = item
-				} else {
-					let retainArr = this.selectedArr.slice(0, layer + 1)
-					this.selectedArr = retainArr.concat(item)
-				}
-				this.$nextTick(() => {
-					this.currentTab = this.selectedArr.length - 1
-				})
-			}
-		}
-	}
+      if (!this.request) {
+        const data = this.getItemList(index, subIndex)
+        this.subLevelData(data, index)
+      }
+    },
+    subLevelData(data, layer) {
+      if (!data || data.length === 0) {
+        if (layer === -1) return
+        let result = JSON.parse(JSON.stringify(this.selectedArr))
+        const lastItem = result[result.length - 1] || {}
+        const text = []
+        result = result.map(item => {
+          text.push(item[this.labelKey])
+          const clone = { ...item }
+          delete clone.list
+          return clone
+        })
+        this.$emit('complete', {
+          result,
+          [this.valueKey]: lastItem[this.valueKey],
+          [this.labelKey]: text.join('/'),
+          [this.descKey]: lastItem[this.descKey],
+          src: lastItem.src,
+        })
+      } else {
+        const item = [
+          {
+            [this.labelKey]: this.text,
+            [this.descKey]: '',
+            [this.valueKey]: '',
+            src: '',
+            index: -1,
+            list: data,
+          },
+        ]
+        if (layer === -1) {
+          this.selectedArr = item
+        } else {
+          const retainArr = this.selectedArr.slice(0, layer + 1)
+          this.selectedArr = retainArr.concat(item)
+        }
+        this.$nextTick(() => {
+          this.currentTab = this.selectedArr.length - 1
+        })
+      }
+    },
+  },
 }
 </script>
 
 <style scoped>
 .wf-cascade-selection {
-	width: 100%;
-	box-sizing: border-box;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .wf-cascade-title {
-	width: 100%;
-	display: -webkit-box;
-	display: -webkit-flex;
-	display: flex;
-	-webkit-box-align: center;
-	-webkit-align-items: center;
-	align-items: center;
-	-webkit-box-pack: center;
-	-webkit-justify-content: center;
-	justify-content: center;
-	padding: 10px;
-	box-sizing: border-box;
-	background-color: #fff;
-	border-top-left-radius: 10px;
-	border-top-right-radius: 10px;
-	overflow: hidden;
-	position: relative;
-	font-size: 36rpx;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  box-sizing: border-box;
+  background-color: #fff;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  overflow: hidden;
+  position: relative;
+  font-size: 36px;
+}
+
+.wf-scroll-x {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  scroll-behavior: smooth;
 }
 
 .wf-selection-header {
-	width: 100%;
-	display: flex;
-	align-items: center;
-	position: relative;
-	box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
 }
 
 .wf-bottom-line {
-	position: relative;
+  position: relative;
 }
 
 .wf-bottom-line::after {
-	width: 100%;
-	content: '';
-	position: absolute;
-	border-bottom: 1rpx solid #eaeef1;
-	-webkit-transform: scaleY(0.5) translateZ(0);
-	transform: scaleY(0.5) translateZ(0);
-	transform-origin: 0 100%;
-	bottom: 0;
-	right: 0;
-	left: 0;
+  width: 100%;
+  content: '';
+  position: absolute;
+  border-bottom: 1px solid #eaeef1;
+  transform: scaleY(0.5) translateZ(0);
+  transform-origin: 0 100%;
+  bottom: 0;
+  right: 0;
+  left: 0;
 }
 
 .wf-btm-none::after {
-	border-bottom: 0 !important;
+  border-bottom: 0 !important;
 }
 
 .wf-header-item {
-	max-width: 240rpx;
-	padding: 15rpx 30rpx;
-	box-sizing: border-box;
-	flex-shrink: 0;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	position: relative;
+  max-width: 240px;
+  padding: 15px 30px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  position: relative;
 }
 
 .wf-font-bold {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 .wf-active-line {
-	width: 60rpx;
-	height: 6rpx;
-	border-radius: 4rpx;
-	position: absolute;
-	bottom: 16rpx;
-	right: 0;
-	left: 50%;
-	transform: translateX(-50%);
+  width: 60px;
+  height: 6px;
+  border-radius: 4px;
+  position: absolute;
+  bottom: 16px;
+  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.wf-selection-list {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.wf-selection-panel {
+  height: 100%;
+}
+
+.wf-selection-item {
+  width: 100%;
+  box-sizing: border-box;
+  overflow-y: auto;
+  scroll-behavior: smooth;
 }
 
 .wf-selection-cell {
-	width: 100%;
-	box-sizing: border-box;
-	display: flex;
-	align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
 }
 
 .wf-icon-success {
-	margin-right: 12rpx;
+  margin-right: 12px;
 }
 
 .wf-cell-img {
-	margin-right: 12rpx;
-	flex-shrink: 0;
+  margin-right: 12px;
+  flex-shrink: 0;
 }
 
 .wf-cell-title {
-	word-break: break-all;
+  word-break: break-all;
 }
 
 .wf-flex-shrink {
-	flex-shrink: 0;
-}
-
-.wf-font-bold {
-	font-weight: bold;
+  flex-shrink: 0;
 }
 
 .wf-cell-sub_title {
-	margin-left: 20rpx;
-	word-break: break-all;
+  margin-left: 20px;
+  word-break: break-all;
 }
+
 .wf-first-item {
-	width: 100%;
+  width: 100%;
 }
 </style>

--- a/src/components/wf-ui/components/wf-cascader/wf-cascader.vue
+++ b/src/components/wf-ui/components/wf-cascader/wf-cascader.vue
@@ -1,15 +1,15 @@
 <template>
-	<view class="wf-cascader">
-		<u-input
-			v-model="textLabel"
-			type="select"
-			:placeholder="getPlaceholder(column, column.type)"
-			@click="onClick"
-		/>
-		<u-popup v-model="show" mode="bottom" close-icon="close-circle" closeable>
-			<cascader :props="column.props" :itemList="dic" :title="column.label" @complete="onConfirm"></cascader>
-		</u-popup>
-	</view>
+  <div class="wf-cascader">
+    <u-input
+      v-model="textLabel"
+      type="select"
+      :placeholder="getPlaceholder(column, column.type)"
+      @click="onClick"
+    />
+    <u-popup v-model="show" mode="bottom" close-icon="close-circle" closeable>
+      <cascader :props="column.props" :item-list="dic" :title="column.label" @complete="onConfirm" />
+    </u-popup>
+  </div>
 </template>
 
 <script>
@@ -17,7 +17,7 @@ import Props from '../../mixins/props.js'
 
 import Cascader from './components/cascader'
 export default {
-	name: 'wf-cascader',
+        name: 'WfCascader',
 	components: { Cascader },
 	mixins: [Props],
 	watch: {
@@ -52,10 +52,10 @@ export default {
 
 <style lang="scss" scoped>
 .wf-cascader {
-	width: 100%;
+  width: 100%;
 
-	::v-deep.u-close--top-right {
-		top: 20rpx;
-	}
+  ::v-deep.u-close--top-right {
+    top: 20px;
+  }
 }
 </style>

--- a/src/components/wf-ui/index.js
+++ b/src/components/wf-ui/index.js
@@ -1,4 +1,5 @@
 import { validateNull, validData, deepClone, findObject } from './util/index.js';
+import { registerVantAdapters } from './adapter/registerVantAdapters.js';
 
 const prototypes = {
     validateNull,
@@ -9,12 +10,12 @@ const prototypes = {
 };
 
 export default {
-    install(Vue) {
-        // 注册全局方法
+    install(app) {
+        const target = app?.config?.globalProperties ?? app.prototype;
         Object.keys(prototypes).forEach((key) => {
-            Vue.prototype[key] = prototypes[key];
-            uni.$u[key] = prototypes[key];
+            target[key] = prototypes[key];
         });
+        registerVantAdapters(app);
     },
     author: 'SSC',
     version: '1.4.0',


### PR DESCRIPTION
## Summary
- add a Vant adapter layer for wf-ui so legacy uView component tags are backed by Vant implementations
- implement wrapper components for popups, selects, forms, buttons, load more, and other base widgets using Vant primitives
- update the wf-ui plugin install hook to register the new adapters alongside existing helper utilities

## Testing
- npm run lint *(fails: existing lint issues across legacy wf-ui files outside the new adapter layer)*

------
https://chatgpt.com/codex/tasks/task_e_68f1b3514b108327be8ce9b9aebab549