### PR TITLE
feat: add inbound order workflow pages

### DIFF
--- a/src/composables/useInboundOrders.js
+++ b/src/composables/useInboundOrders.js
@@ -1,0 +1,142 @@
+import { computed, ref } from 'vue';
+import dayjs from 'dayjs';
+
+const createSeedOrders = () => [
+  {
+    id: 'RK20241001001',
+    inboundNo: 'RK20241001001',
+    locatorNo: 'A-01-01',
+    createdAt: '2024-10-01 09:12',
+    createdBy: '李晓明',
+    remark: '首批到货，优先处理',
+    items: [
+      {
+        id: 'ITEM-1',
+        bomNo: 'BOM-01-001',
+        bomVersion: 'V3.2',
+        drawAddress: 'https://example.com/draw/1',
+        drawQty: 120,
+        exeMaterialNumber: 'MAT-0001',
+        exeMaterialName: '电源线组件',
+        finishMaterialNumber: 'FIN-9001',
+        finishMaterialName: '终端电源线',
+        mtoNo: 'MTO-202409-01',
+        unit: 'PCS',
+        no: 'DC-EXEC-202409-01',
+        isQualified: '1',
+        execeptionType: '',
+        remark: '外观正常',
+      },
+      {
+        id: 'ITEM-2',
+        bomNo: 'BOM-02-010',
+        bomVersion: 'V1.8',
+        drawAddress: 'https://example.com/draw/2',
+        drawQty: 60,
+        exeMaterialNumber: 'MAT-0002',
+        exeMaterialName: '信号线束',
+        finishMaterialNumber: 'FIN-9002',
+        finishMaterialName: '成品信号线束',
+        mtoNo: 'MTO-202409-02',
+        unit: 'PCS',
+        no: 'DC-EXEC-202409-02',
+        isQualified: '0',
+        execeptionType: '表面瑕疵',
+        remark: '外皮存在划痕',
+      },
+    ],
+  },
+  {
+    id: 'RK20241002003',
+    inboundNo: 'RK20241002003',
+    locatorNo: 'B-03-07',
+    createdAt: '2024-10-02 14:35',
+    createdBy: '王婷婷',
+    remark: '常规入库',
+    items: [
+      {
+        id: 'ITEM-3',
+        bomNo: 'BOM-08-020',
+        bomVersion: 'V2.1',
+        drawAddress: 'https://example.com/draw/8',
+        drawQty: 45,
+        exeMaterialNumber: 'MAT-0010',
+        exeMaterialName: '控制线组件',
+        finishMaterialNumber: 'FIN-9010',
+        finishMaterialName: '控制线成品',
+        mtoNo: 'MTO-202410-08',
+        unit: 'PCS',
+        no: 'DC-EXEC-202410-08',
+        isQualified: '1',
+        execeptionType: '',
+        remark: '尺寸合格',
+      },
+    ],
+  },
+];
+
+const ordersRef = ref(createSeedOrders());
+
+const generateOrderId = () => {
+  const timestamp = dayjs().format('YYYYMMDDHHmmss');
+  const randomSuffix = Math.floor(Math.random() * 900 + 100);
+  return `RK${timestamp}${randomSuffix}`;
+};
+
+const generateItemId = () => `ITEM-${Math.random().toString(36).slice(2, 8)}`;
+
+const decorateOrder = (payload) => {
+  const createdAt = payload.createdAt ?? dayjs().format('YYYY-MM-DD HH:mm');
+  const inboundNo = payload.inboundNo ?? generateOrderId();
+  const id = payload.id ?? inboundNo;
+  const items = (payload.items ?? []).map((item) => ({
+    ...item,
+    id: item.id ?? generateItemId(),
+    drawQty: Number(item.drawQty ?? 0),
+    isQualified: item.isQualified ?? '1',
+    execeptionType: item.execeptionType ?? '',
+  }));
+
+  return {
+    id,
+    inboundNo,
+    locatorNo: payload.locatorNo ?? '',
+    createdAt,
+    createdBy: payload.createdBy ?? '当前用户',
+    remark: payload.remark ?? '',
+    items,
+  };
+};
+
+export default function useInboundOrders() {
+  const orders = ordersRef;
+
+  const totalCount = computed(() =>
+    orders.value.reduce((acc, order) => acc + (order.items?.length ?? 0), 0)
+  );
+
+  const addOrder = (payload) => {
+    const order = decorateOrder(payload);
+    orders.value = [order, ...orders.value];
+    return order;
+  };
+
+  const getOrderById = (id) => orders.value.find((item) => item.id === id);
+
+  const updateOrder = (id, updater) => {
+    orders.value = orders.value.map((order) => {
+      if (order.id !== id) return order;
+      const next = typeof updater === 'function' ? updater(order) : { ...order, ...updater };
+      return decorateOrder({ ...order, ...next, id: order.id, inboundNo: order.inboundNo });
+    });
+    return orders.value.find((order) => order.id === id);
+  };
+
+  return {
+    orders,
+    totalCount,
+    addOrder,
+    getOrderById,
+    updateOrder,
+  };
+}

--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -22,9 +22,27 @@ export default {
     },
     {
       path: 'inbound-order',
-      name: 'appsInboundOrder',
-      meta: { title: '入库单', requiresAuth: true },
-      component: () => import('@/views/apps/InboundOrder.vue'),
+      component: () => import('@/views/apps/InboundOrder/index.vue'),
+      children: [
+        {
+          path: '',
+          name: 'appsInboundOrder',
+          meta: { title: '入库单', requiresAuth: true },
+          component: () => import('@/views/apps/InboundOrder/List.vue'),
+        },
+        {
+          path: 'create',
+          name: 'appsInboundOrderCreate',
+          meta: { title: '新增入库单', requiresAuth: true },
+          component: () => import('@/views/apps/InboundOrder/Create.vue'),
+        },
+        {
+          path: ':id',
+          name: 'appsInboundOrderDetail',
+          meta: { title: '入库单详情', requiresAuth: true },
+          component: () => import('@/views/apps/InboundOrder/Detail.vue'),
+        },
+      ],
     },
     {
       path: 'site-planning',

--- a/src/views/apps/InboundOrder.vue
+++ b/src/views/apps/InboundOrder.vue
@@ -1,7 +1,0 @@
-<template>
-  <AppPage title="入库单" />
-</template>
-
-<script setup>
-import AppPage from './components/AppPage.vue';
-</script>

--- a/src/views/apps/InboundOrder/Create.vue
+++ b/src/views/apps/InboundOrder/Create.vue
@@ -1,0 +1,248 @@
+<template>
+  <div class="page inbound-order-create">
+    <van-nav-bar
+      fixed
+      :z-index="999"
+      title="新增入库单"
+      left-arrow
+      :style="{ background: '#F7EEE8' }"
+      @click-left="goBack"
+    />
+
+    <div class="page-body">
+      <van-form ref="formRef" @submit="handleSubmit">
+        <van-cell-group inset>
+          <van-field
+            v-model="form.locatorNo"
+            label="库位编码"
+            placeholder="请输入库位编码"
+            :rules="[{ required: true, message: '请输入库位编码' }]"
+          />
+          <van-field v-model="form.remark" label="备注" placeholder="请输入备注" />
+        </van-cell-group>
+
+        <div class="section">
+          <div class="section__header">
+            <h3>入库明细</h3>
+            <van-button plain size="small" type="primary" @click="addItem">
+              <van-icon name="plus" size="14" /> 添加明细
+            </van-button>
+          </div>
+
+          <div v-if="form.items.length" class="items">
+            <div v-for="(item, index) in form.items" :key="item.id" class="item-card">
+              <div class="item-card__header">
+                <span class="index">#{{ index + 1 }}</span>
+                <van-button size="mini" type="danger" plain @click="removeItem(index)">删除</van-button>
+              </div>
+              <van-cell-group inset>
+                <van-field v-model="item.bomNo" label="BOM编码" placeholder="请输入" />
+                <van-field v-model="item.bomVersion" label="BOM版本" placeholder="请输入" />
+                <van-field v-model="item.no" label="执行单单号" placeholder="请输入" />
+                <van-field v-model="item.exeMaterialNumber" label="物料编码" placeholder="请输入" />
+                <van-field v-model="item.exeMaterialName" label="物料名称" placeholder="请输入" />
+                <van-field v-model="item.finishMaterialNumber" label="成品物料编码" placeholder="请输入" />
+                <van-field v-model="item.finishMaterialName" label="成品物料名称" placeholder="请输入" />
+                <van-field v-model="item.mtoNo" label="专案号" placeholder="请输入" />
+                <van-field v-model="item.unit" label="单位" placeholder="请输入" />
+                <van-field
+                  v-model.number="item.drawQty"
+                  label="图档数量"
+                  type="digit"
+                  placeholder="请输入数量"
+                  :rules="[{ required: true, message: '请输入图档数量' }]"
+                />
+                <div class="field-block">
+                  <div class="field-block__label">是否合格</div>
+                  <van-radio-group v-model="item.isQualified" direction="horizontal">
+                    <van-radio name="1">合格</van-radio>
+                    <van-radio name="0">不合格</van-radio>
+                  </van-radio-group>
+                </div>
+                <van-field
+                  v-if="item.isQualified === '0'"
+                  v-model="item.execeptionType"
+                  label="异常类型"
+                  placeholder="请输入异常类型"
+                />
+                <van-field v-model="item.remark" label="备注" type="textarea" rows="2" placeholder="请输入备注" />
+              </van-cell-group>
+            </div>
+          </div>
+          <van-empty v-else description="请添加入库明细" />
+        </div>
+
+        <div class="form-footer">
+          <van-button block type="success" native-type="submit">保存入库单</van-button>
+        </div>
+      </van-form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue';
+import { showSuccessToast, showToast } from 'vant';
+import { useRouter } from 'vue-router';
+import useInboundOrders from '@/composables/useInboundOrders';
+
+const router = useRouter();
+const { addOrder } = useInboundOrders();
+
+const form = reactive({
+  locatorNo: '',
+  remark: '',
+  items: [],
+});
+
+const goBack = () => {
+  router.back();
+};
+
+const createEmptyItem = () => ({
+  id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
+  bomNo: '',
+  bomVersion: '',
+  drawAddress: '',
+  drawQty: null,
+  exeMaterialNumber: '',
+  exeMaterialName: '',
+  finishMaterialNumber: '',
+  finishMaterialName: '',
+  mtoNo: '',
+  unit: '',
+  no: '',
+  isQualified: '1',
+  execeptionType: '',
+  remark: '',
+});
+
+const addItem = () => {
+  form.items.push(createEmptyItem());
+};
+
+const removeItem = (index) => {
+  form.items.splice(index, 1);
+};
+
+const validateForm = () => {
+  if (!form.locatorNo) {
+    showToast({ type: 'fail', message: '请输入库位编码' });
+    return false;
+  }
+  if (!form.items.length) {
+    showToast({ type: 'fail', message: '请添加入库明细' });
+    return false;
+  }
+  const invalidIndex = form.items.findIndex((item) => item.drawQty === null || item.drawQty === '');
+  if (invalidIndex !== -1) {
+    showToast({ type: 'fail', message: `请填写第 ${invalidIndex + 1} 行的图档数量` });
+    return false;
+  }
+  return true;
+};
+
+const resetForm = () => {
+  form.locatorNo = '';
+  form.remark = '';
+  form.items = [];
+};
+
+const handleSubmit = () => {
+  if (!validateForm()) {
+    return;
+  }
+  const order = addOrder({
+    locatorNo: form.locatorNo,
+    remark: form.remark,
+    items: form.items.map((item) => ({
+      ...item,
+      drawQty: Number(item.drawQty ?? 0),
+    })),
+  });
+
+  resetForm();
+  showSuccessToast('保存成功');
+  router.replace({ name: 'appsInboundOrderDetail', params: { id: order.id } });
+};
+</script>
+
+<style scoped>
+.page {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+
+.page-body {
+  padding: 96px 16px 120px;
+  box-sizing: border-box;
+}
+
+.section {
+  margin-top: 16px;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
+}
+
+.section__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.section__header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.item-card {
+  border: 1px solid #f0f0f0;
+  border-radius: 12px;
+  padding: 12px;
+  background: #fff7f0;
+}
+
+.item-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.item-card__header .index {
+  font-weight: 600;
+  color: #d05507;
+}
+
+.field-block {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  font-size: 14px;
+}
+
+.field-block__label {
+  color: #646566;
+}
+
+.form-footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.05);
+}
+</style>

--- a/src/views/apps/InboundOrder/Detail.vue
+++ b/src/views/apps/InboundOrder/Detail.vue
@@ -1,0 +1,231 @@
+<template>
+  <div class="page inbound-order-detail">
+    <van-nav-bar
+      fixed
+      :z-index="999"
+      title="入库单详情"
+      left-arrow
+      :style="{ background: '#F7EEE8' }"
+      @click-left="goBack"
+    />
+
+    <div v-if="order" class="page-body">
+      <van-cell-group inset>
+        <van-cell title="入库单号" :value="order.inboundNo" />
+        <van-cell title="库位编码" :value="order.locatorNo || '-'" />
+        <van-cell title="创建人" :value="order.createdBy" />
+        <van-cell title="创建时间" :value="order.createdAt" />
+        <van-cell title="备注" :value="order.remark || '-'" />
+      </van-cell-group>
+
+      <div class="section">
+        <div class="section__header">
+          <h3>入库明细</h3>
+          <van-tag :type="status.type">{{ status.label }}</van-tag>
+        </div>
+
+        <div v-for="(item, index) in order.items" :key="item.id" class="detail-card">
+          <div class="detail-card__header">
+            <span class="index">#{{ index + 1 }}</span>
+            <span class="material">{{ item.exeMaterialName || '-' }}</span>
+          </div>
+          <div class="detail-card__grid">
+            <div class="grid-item">
+              <span class="label">BOM编码</span>
+              <span class="value">{{ item.bomNo || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">BOM版本</span>
+              <span class="value">{{ item.bomVersion || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">执行单单号</span>
+              <span class="value">{{ item.no || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">物料编码</span>
+              <span class="value">{{ item.exeMaterialNumber || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">成品物料编码</span>
+              <span class="value">{{ item.finishMaterialNumber || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">成品物料名称</span>
+              <span class="value">{{ item.finishMaterialName || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">专案号</span>
+              <span class="value">{{ item.mtoNo || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">单位</span>
+              <span class="value">{{ item.unit || '-' }}</span>
+            </div>
+            <div class="grid-item">
+              <span class="label">图档数量</span>
+              <span class="value highlight">{{ item.drawQty }}</span>
+            </div>
+          </div>
+          <div class="detail-card__footer">
+            <div>
+              <span class="label">是否合格：</span>
+              <van-tag :type="item.isQualified === '1' ? 'success' : 'danger'">
+                {{ item.isQualified === '1' ? '合格' : '不合格' }}
+              </van-tag>
+            </div>
+            <div>
+              <span class="label">异常类型：</span>
+              <span class="value">{{ item.execeptionType || '-' }}</span>
+            </div>
+            <div>
+              <span class="label">备注：</span>
+              <span class="value">{{ item.remark || '-' }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="page-empty">
+      <van-empty description="未找到入库单">
+        <van-button round type="primary" @click="goBack">返回</van-button>
+      </van-empty>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import useInboundOrders from '@/composables/useInboundOrders';
+
+const route = useRoute();
+const router = useRouter();
+const { getOrderById } = useInboundOrders();
+
+const order = computed(() => getOrderById(route.params.id));
+
+const status = computed(() => {
+  if (!order.value) {
+    return { label: '-', type: 'primary' };
+  }
+  const hasException = order.value.items.some((item) => item.isQualified === '0');
+  return hasException
+    ? { label: '存在异常', type: 'danger' }
+    : { label: '全部合格', type: 'success' };
+});
+
+const goBack = () => {
+  router.back();
+};
+</script>
+
+<style scoped>
+.page {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+
+.page-body {
+  padding: 96px 16px 24px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
+}
+
+.section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.section__header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: #333;
+}
+
+.detail-card {
+  border: 1px solid #f0f0f0;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background: #fff7f0;
+}
+
+.detail-card:last-of-type {
+  margin-bottom: 0;
+}
+
+.detail-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.detail-card__header .index {
+  font-weight: 600;
+  color: #d05507;
+}
+
+.detail-card__header .material {
+  font-size: 14px;
+  color: #333;
+}
+
+.detail-card__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  font-size: 13px;
+  color: #555;
+}
+
+.grid-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.grid-item .label {
+  color: #999;
+  margin-bottom: 4px;
+}
+
+.grid-item .value {
+  color: #333;
+}
+
+.highlight {
+  font-weight: 600;
+  color: #d05507;
+}
+
+.detail-card__footer {
+  margin-top: 16px;
+  display: grid;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.detail-card__footer .label {
+  color: #999;
+}
+
+.page-empty {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/views/apps/InboundOrder/List.vue
+++ b/src/views/apps/InboundOrder/List.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="page inbound-order-list">
+    <van-nav-bar
+      fixed
+      :z-index="999"
+      title="入库单"
+      left-arrow
+      :style="{ background: '#F7EEE8' }"
+      @click-left="goBack"
+    />
+
+    <div class="page-body">
+      <div class="toolbar">
+        <div class="toolbar__meta">
+          <span class="toolbar__label">入库单数量</span>
+          <span class="toolbar__value">{{ displayOrders.length }}</span>
+        </div>
+        <div class="toolbar__meta">
+          <span class="toolbar__label">总明细</span>
+          <span class="toolbar__value">{{ totalCount }}</span>
+        </div>
+        <van-button type="primary" size="small" class="toolbar__button" @click="handleCreate">
+          <van-icon name="plus" size="16" /> 新增入库单
+        </van-button>
+      </div>
+
+      <van-pull-refresh v-model="refreshing" class="list-wrapper" @refresh="onRefresh">
+        <template v-if="displayOrders.length">
+          <div
+            v-for="order in displayOrders"
+            :key="order.id"
+            class="order-card"
+            @click="openDetail(order.id)"
+          >
+            <div class="order-card__header">
+              <div class="order-card__title">{{ order.inboundNo }}</div>
+              <van-tag :type="getStatus(order).type">{{ getStatus(order).label }}</van-tag>
+            </div>
+            <div class="order-card__meta">
+              <span>库位：{{ order.locatorNo || '-' }}</span>
+              <span>创建人：{{ order.createdBy }}</span>
+            </div>
+            <div class="order-card__meta">
+              <span>创建时间：{{ order.createdAt }}</span>
+              <span>明细：{{ order.items.length }} 条</span>
+            </div>
+            <div class="order-card__footer">
+              <div class="order-card__footer-item">
+                <span class="label">图档数量合计</span>
+                <span class="value">{{ sumDrawQty(order.items) }}</span>
+              </div>
+              <div class="order-card__footer-item">
+                <span class="label">备注</span>
+                <span class="value">{{ order.remark || '-' }}</span>
+              </div>
+            </div>
+          </div>
+        </template>
+        <template v-else>
+          <van-empty description="暂无入库单">
+            <van-button round type="primary" @click="handleCreate">新增入库单</van-button>
+          </van-empty>
+        </template>
+      </van-pull-refresh>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import dayjs from 'dayjs';
+import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import useInboundOrders from '@/composables/useInboundOrders';
+
+const router = useRouter();
+const { orders, totalCount } = useInboundOrders();
+const refreshing = ref(false);
+
+const displayOrders = computed(() =>
+  [...orders.value].sort(
+    (a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf()
+  )
+);
+
+const goBack = () => {
+  router.back();
+};
+
+const handleCreate = () => {
+  router.push({ name: 'appsInboundOrderCreate' });
+};
+
+const openDetail = (id) => {
+  router.push({ name: 'appsInboundOrderDetail', params: { id } });
+};
+
+const sumDrawQty = (items = []) =>
+  items.reduce((acc, item) => acc + Number(item.drawQty ?? 0), 0);
+
+const getStatus = (order) => {
+  const hasException = order.items.some((item) => item.isQualified === '0');
+  return hasException
+    ? { label: '存在异常', type: 'danger' }
+    : { label: '全部合格', type: 'success' };
+};
+
+const onRefresh = () => {
+  setTimeout(() => {
+    refreshing.value = false;
+  }, 500);
+};
+</script>
+
+<style scoped>
+.page {
+  min-height: 100vh;
+  background: #f7f8fa;
+}
+
+.page-body {
+  padding: 96px 16px 24px;
+  box-sizing: border-box;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 16px;
+  margin-bottom: 16px;
+}
+
+.toolbar__meta {
+  display: flex;
+  flex-direction: column;
+  background: #fff3e8;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.toolbar__label {
+  font-size: 12px;
+  color: #a05c2f;
+}
+
+.toolbar__value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #d05507;
+}
+
+.toolbar__button {
+  margin-left: auto;
+}
+
+.list-wrapper {
+  min-height: calc(100vh - 168px);
+}
+
+.order-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
+  margin-bottom: 16px;
+}
+
+.order-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.order-card__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333333;
+}
+
+.order-card__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #666;
+  margin-bottom: 6px;
+}
+
+.order-card__footer {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #f0f0f0;
+  display: grid;
+  gap: 8px;
+}
+
+.order-card__footer-item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.order-card__footer-item .label {
+  color: #999;
+}
+
+.order-card__footer-item .value {
+  color: #333;
+}
+</style>

--- a/src/views/apps/InboundOrder/index.vue
+++ b/src/views/apps/InboundOrder/index.vue
@@ -1,0 +1,6 @@
+<template>
+  <router-view />
+</template>
+
+<script setup>
+</script>


### PR DESCRIPTION
## Summary
- replace the placeholder inbound order route with a nested workflow for list, detail and create pages
- add a shared inbound order store with seeded data to drive the new pages without a backend
- implement responsive Vant-based UIs for listing orders, showing details, and adding new orders

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f20bd8e7a08327b03ab7fc8a105852