### PR TITLE
feat: migrate inbound order module to vant

### DIFF
--- a/src/composables/useInboundOrders.js
+++ b/src/composables/useInboundOrders.js
@@ -1,75 +1,65 @@
 import { computed, ref } from 'vue';
 import dayjs from 'dayjs';
 
+export const INBOUND_STATUS_META = {
+  DC_WMS_IN_STATUS_A: { label: '待审核', type: 'warning' },
+  DC_WMS_IN_STATUS_C: { label: '已审核', type: 'success' },
+};
+
+const resolveStatusMeta = (status) =>
+  INBOUND_STATUS_META[status] ?? { label: '已完成', type: 'primary' };
+
 const createSeedOrders = () => [
   {
     id: 'RK20241001001',
-    inboundNo: 'RK20241001001',
-    locatorNo: 'A-01-01',
-    createdAt: '2024-10-01 09:12',
-    createdBy: '李晓明',
+    inStockCode: 'RK20241001001',
+    inStockStatus: 'DC_WMS_IN_STATUS_C',
+    inStockNumber: 'SRC-20241001-01',
+    warehouseName: '一号成品仓',
+    applicantName: '李晓明',
+    processingPersonnelName: '张主管',
+    createTime: '2024-10-01 09:12',
     remark: '首批到货，优先处理',
-    items: [
+    detailList: [
       {
         id: 'ITEM-1',
-        bomNo: 'BOM-01-001',
-        bomVersion: 'V3.2',
-        drawAddress: 'https://example.com/draw/1',
-        drawQty: 120,
-        exeMaterialNumber: 'MAT-0001',
-        exeMaterialName: '电源线组件',
-        finishMaterialNumber: 'FIN-9001',
-        finishMaterialName: '终端电源线',
-        mtoNo: 'MTO-202409-01',
-        unit: 'PCS',
-        no: 'DC-EXEC-202409-01',
-        isQualified: '1',
-        execeptionType: '',
-        remark: '外观正常',
+        productCode: 'MAT-0001',
+        productName: '电源线组件',
+        productSpec: '1.5m/国标',
+        productQty: 120,
+        productUnit: 'PCS',
+        locationCode: 'A-01-01',
       },
       {
         id: 'ITEM-2',
-        bomNo: 'BOM-02-010',
-        bomVersion: 'V1.8',
-        drawAddress: 'https://example.com/draw/2',
-        drawQty: 60,
-        exeMaterialNumber: 'MAT-0002',
-        exeMaterialName: '信号线束',
-        finishMaterialNumber: 'FIN-9002',
-        finishMaterialName: '成品信号线束',
-        mtoNo: 'MTO-202409-02',
-        unit: 'PCS',
-        no: 'DC-EXEC-202409-02',
-        isQualified: '0',
-        execeptionType: '表面瑕疵',
-        remark: '外皮存在划痕',
+        productCode: 'MAT-0002',
+        productName: '信号线束',
+        productSpec: '8芯/屏蔽',
+        productQty: 60,
+        productUnit: 'PCS',
+        locationCode: 'A-01-01',
       },
     ],
   },
   {
     id: 'RK20241002003',
-    inboundNo: 'RK20241002003',
-    locatorNo: 'B-03-07',
-    createdAt: '2024-10-02 14:35',
-    createdBy: '王婷婷',
-    remark: '常规入库',
-    items: [
+    inStockCode: 'RK20241002003',
+    inStockStatus: 'DC_WMS_IN_STATUS_A',
+    inStockNumber: 'SRC-20241002-03',
+    warehouseName: '二号原料仓',
+    applicantName: '王婷婷',
+    processingPersonnelName: '刘主管',
+    createTime: '2024-10-02 14:35',
+    remark: '常规入库批次',
+    detailList: [
       {
         id: 'ITEM-3',
-        bomNo: 'BOM-08-020',
-        bomVersion: 'V2.1',
-        drawAddress: 'https://example.com/draw/8',
-        drawQty: 45,
-        exeMaterialNumber: 'MAT-0010',
-        exeMaterialName: '控制线组件',
-        finishMaterialNumber: 'FIN-9010',
-        finishMaterialName: '控制线成品',
-        mtoNo: 'MTO-202410-08',
-        unit: 'PCS',
-        no: 'DC-EXEC-202410-08',
-        isQualified: '1',
-        execeptionType: '',
-        remark: '尺寸合格',
+        productCode: 'MAT-0010',
+        productName: '控制线组件',
+        productSpec: '6芯/2m',
+        productQty: 45,
+        productUnit: 'PCS',
+        locationCode: 'B-03-07',
       },
     ],
   },
@@ -86,25 +76,26 @@ const generateOrderId = () => {
 const generateItemId = () => `ITEM-${Math.random().toString(36).slice(2, 8)}`;
 
 const decorateOrder = (payload) => {
-  const createdAt = payload.createdAt ?? dayjs().format('YYYY-MM-DD HH:mm');
-  const inboundNo = payload.inboundNo ?? generateOrderId();
-  const id = payload.id ?? inboundNo;
-  const items = (payload.items ?? []).map((item) => ({
+  const createdAt = payload.createTime ?? dayjs().format('YYYY-MM-DD HH:mm');
+  const inStockCode = payload.inStockCode ?? generateOrderId();
+  const id = payload.id ?? inStockCode;
+  const detailList = (payload.detailList ?? []).map((item) => ({
     ...item,
     id: item.id ?? generateItemId(),
-    drawQty: Number(item.drawQty ?? 0),
-    isQualified: item.isQualified ?? '1',
-    execeptionType: item.execeptionType ?? '',
+    productQty: Number(item.productQty ?? 0),
   }));
 
   return {
     id,
-    inboundNo,
-    locatorNo: payload.locatorNo ?? '',
-    createdAt,
-    createdBy: payload.createdBy ?? '当前用户',
+    inStockCode,
+    inStockStatus: payload.inStockStatus ?? 'DC_WMS_IN_STATUS_A',
+    inStockNumber: payload.inStockNumber ?? '',
+    warehouseName: payload.warehouseName ?? '',
+    applicantName: payload.applicantName ?? '当前用户',
+    processingPersonnelName: payload.processingPersonnelName ?? '当前用户',
+    createTime: createdAt,
     remark: payload.remark ?? '',
-    items,
+    detailList,
   };
 };
 
@@ -112,7 +103,7 @@ export default function useInboundOrders() {
   const orders = ordersRef;
 
   const totalCount = computed(() =>
-    orders.value.reduce((acc, order) => acc + (order.items?.length ?? 0), 0)
+    orders.value.reduce((acc, order) => acc + (order.detailList?.length ?? 0), 0)
   );
 
   const addOrder = (payload) => {
@@ -127,7 +118,7 @@ export default function useInboundOrders() {
     orders.value = orders.value.map((order) => {
       if (order.id !== id) return order;
       const next = typeof updater === 'function' ? updater(order) : { ...order, ...updater };
-      return decorateOrder({ ...order, ...next, id: order.id, inboundNo: order.inboundNo });
+      return decorateOrder({ ...order, ...next, id: order.id, inStockCode: order.inStockCode });
     });
     return orders.value.find((order) => order.id === id);
   };
@@ -138,5 +129,6 @@ export default function useInboundOrders() {
     addOrder,
     getOrderById,
     updateOrder,
+    resolveStatusMeta,
   };
 }

--- a/src/views/apps/InboundOrder/Create.vue
+++ b/src/views/apps/InboundOrder/Create.vue
@@ -13,10 +13,26 @@
       <van-form ref="formRef" @submit="handleSubmit">
         <van-cell-group inset>
           <van-field
-            v-model="form.locatorNo"
-            label="库位编码"
-            placeholder="请输入库位编码"
-            :rules="[{ required: true, message: '请输入库位编码' }]"
+            v-model="form.warehouseName"
+            label="仓库名称"
+            placeholder="请输入仓库名称"
+            :rules="[{ required: true, message: '请输入仓库名称' }]"
+          />
+          <van-field
+            v-model="form.inStockNumber"
+            label="来源单号"
+            placeholder="请输入来源单号"
+            :rules="[{ required: true, message: '请输入来源单号' }]"
+          />
+          <van-field
+            v-model="form.processingPersonnelName"
+            label="处理人"
+            placeholder="请输入处理人"
+          />
+          <van-field
+            v-model="form.applicantName"
+            label="申请人"
+            placeholder="请输入申请人"
           />
           <van-field v-model="form.remark" label="备注" placeholder="请输入备注" />
         </van-cell-group>
@@ -29,42 +45,35 @@
             </van-button>
           </div>
 
-          <div v-if="form.items.length" class="items">
-            <div v-for="(item, index) in form.items" :key="item.id" class="item-card">
+          <div v-if="form.detailList.length" class="items">
+            <div v-for="(item, index) in form.detailList" :key="item.id" class="item-card">
               <div class="item-card__header">
                 <span class="index">#{{ index + 1 }}</span>
                 <van-button size="mini" type="danger" plain @click="removeItem(index)">删除</van-button>
               </div>
               <van-cell-group inset>
-                <van-field v-model="item.bomNo" label="BOM编码" placeholder="请输入" />
-                <van-field v-model="item.bomVersion" label="BOM版本" placeholder="请输入" />
-                <van-field v-model="item.no" label="执行单单号" placeholder="请输入" />
-                <van-field v-model="item.exeMaterialNumber" label="物料编码" placeholder="请输入" />
-                <van-field v-model="item.exeMaterialName" label="物料名称" placeholder="请输入" />
-                <van-field v-model="item.finishMaterialNumber" label="成品物料编码" placeholder="请输入" />
-                <van-field v-model="item.finishMaterialName" label="成品物料名称" placeholder="请输入" />
-                <van-field v-model="item.mtoNo" label="专案号" placeholder="请输入" />
-                <van-field v-model="item.unit" label="单位" placeholder="请输入" />
                 <van-field
-                  v-model.number="item.drawQty"
-                  label="图档数量"
+                  v-model="item.productCode"
+                  label="物料编号"
+                  placeholder="请输入物料编号"
+                  :rules="[{ required: true, message: '请输入物料编号' }]"
+                />
+                <van-field
+                  v-model="item.productName"
+                  label="物料名称"
+                  placeholder="请输入物料名称"
+                  :rules="[{ required: true, message: '请输入物料名称' }]"
+                />
+                <van-field v-model="item.productSpec" label="规格型号" placeholder="请输入规格型号" />
+                <van-field v-model="item.productUnit" label="单位" placeholder="请输入单位" />
+                <van-field
+                  v-model.number="item.productQty"
+                  label="数量"
                   type="digit"
                   placeholder="请输入数量"
-                  :rules="[{ required: true, message: '请输入图档数量' }]"
+                  :rules="[{ required: true, message: '请输入数量' }]"
                 />
-                <div class="field-block">
-                  <div class="field-block__label">是否合格</div>
-                  <van-radio-group v-model="item.isQualified" direction="horizontal">
-                    <van-radio name="1">合格</van-radio>
-                    <van-radio name="0">不合格</van-radio>
-                  </van-radio-group>
-                </div>
-                <van-field
-                  v-if="item.isQualified === '0'"
-                  v-model="item.execeptionType"
-                  label="异常类型"
-                  placeholder="请输入异常类型"
-                />
+                <van-field v-model="item.locationCode" label="仓位编码" placeholder="请输入仓位编码" />
                 <van-field v-model="item.remark" label="备注" type="textarea" rows="2" placeholder="请输入备注" />
               </van-cell-group>
             </div>
@@ -90,9 +99,12 @@ const router = useRouter();
 const { addOrder } = useInboundOrders();
 
 const form = reactive({
-  locatorNo: '',
+  warehouseName: '',
+  inStockNumber: '',
+  processingPersonnelName: '',
+  applicantName: '当前用户',
   remark: '',
-  items: [],
+  detailList: [],
 });
 
 const goBack = () => {
@@ -101,51 +113,56 @@ const goBack = () => {
 
 const createEmptyItem = () => ({
   id: Date.now().toString(36) + Math.random().toString(36).slice(2, 6),
-  bomNo: '',
-  bomVersion: '',
-  drawAddress: '',
-  drawQty: null,
-  exeMaterialNumber: '',
-  exeMaterialName: '',
-  finishMaterialNumber: '',
-  finishMaterialName: '',
-  mtoNo: '',
-  unit: '',
-  no: '',
-  isQualified: '1',
-  execeptionType: '',
+  productCode: '',
+  productName: '',
+  productSpec: '',
+  productQty: null,
+  productUnit: '',
+  locationCode: '',
   remark: '',
 });
 
 const addItem = () => {
-  form.items.push(createEmptyItem());
+  form.detailList.push(createEmptyItem());
 };
 
 const removeItem = (index) => {
-  form.items.splice(index, 1);
+  form.detailList.splice(index, 1);
 };
 
 const validateForm = () => {
-  if (!form.locatorNo) {
-    showToast({ type: 'fail', message: '请输入库位编码' });
+  if (!form.warehouseName) {
+    showToast({ type: 'fail', message: '请输入仓库名称' });
     return false;
   }
-  if (!form.items.length) {
+  if (!form.inStockNumber) {
+    showToast({ type: 'fail', message: '请输入来源单号' });
+    return false;
+  }
+  if (!form.detailList.length) {
     showToast({ type: 'fail', message: '请添加入库明细' });
     return false;
   }
-  const invalidIndex = form.items.findIndex((item) => item.drawQty === null || item.drawQty === '');
+  const invalidIndex = form.detailList.findIndex((item) => item.productQty === null || item.productQty === '');
   if (invalidIndex !== -1) {
-    showToast({ type: 'fail', message: `请填写第 ${invalidIndex + 1} 行的图档数量` });
+    showToast({ type: 'fail', message: `请填写第 ${invalidIndex + 1} 行的数量` });
+    return false;
+  }
+  const missingMaterial = form.detailList.findIndex((item) => !item.productCode || !item.productName);
+  if (missingMaterial !== -1) {
+    showToast({ type: 'fail', message: `请完善第 ${missingMaterial + 1} 行的物料信息` });
     return false;
   }
   return true;
 };
 
 const resetForm = () => {
-  form.locatorNo = '';
+  form.warehouseName = '';
+  form.inStockNumber = '';
+  form.processingPersonnelName = '';
+  form.applicantName = '当前用户';
   form.remark = '';
-  form.items = [];
+  form.detailList = [];
 };
 
 const handleSubmit = () => {
@@ -153,11 +170,14 @@ const handleSubmit = () => {
     return;
   }
   const order = addOrder({
-    locatorNo: form.locatorNo,
+    warehouseName: form.warehouseName,
+    inStockNumber: form.inStockNumber,
+    processingPersonnelName: form.processingPersonnelName,
+    applicantName: form.applicantName,
     remark: form.remark,
-    items: form.items.map((item) => ({
+    detailList: form.detailList.map((item) => ({
       ...item,
-      drawQty: Number(item.drawQty ?? 0),
+      productQty: Number(item.productQty ?? 0),
     })),
   });
 
@@ -222,18 +242,6 @@ const handleSubmit = () => {
 .item-card__header .index {
   font-weight: 600;
   color: #d05507;
-}
-
-.field-block {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  font-size: 14px;
-}
-
-.field-block__label {
-  color: #646566;
 }
 
 .form-footer {

--- a/src/views/apps/InboundOrder/Detail.vue
+++ b/src/views/apps/InboundOrder/Detail.vue
@@ -11,10 +11,12 @@
 
     <div v-if="order" class="page-body">
       <van-cell-group inset>
-        <van-cell title="入库单号" :value="order.inboundNo" />
-        <van-cell title="库位编码" :value="order.locatorNo || '-'" />
-        <van-cell title="创建人" :value="order.createdBy" />
-        <van-cell title="创建时间" :value="order.createdAt" />
+        <van-cell title="入库单号" :value="order.inStockCode" />
+        <van-cell title="来源单号" :value="order.inStockNumber || '-'" />
+        <van-cell title="仓库" :value="order.warehouseName || '-'" />
+        <van-cell title="处理人" :value="order.processingPersonnelName || '-'" />
+        <van-cell title="申请人" :value="order.applicantName || '-'" />
+        <van-cell title="登记时间" :value="order.createTime" />
         <van-cell title="备注" :value="order.remark || '-'" />
       </van-cell-group>
 
@@ -24,63 +26,37 @@
           <van-tag :type="status.type">{{ status.label }}</van-tag>
         </div>
 
-        <div v-for="(item, index) in order.items" :key="item.id" class="detail-card">
+        <div v-for="(item, index) in order.detailList" :key="item.id" class="detail-card">
           <div class="detail-card__header">
             <span class="index">#{{ index + 1 }}</span>
-            <span class="material">{{ item.exeMaterialName || '-' }}</span>
+            <span class="material">{{ item.productName || '-' }}</span>
           </div>
           <div class="detail-card__grid">
             <div class="grid-item">
-              <span class="label">BOM编码</span>
-              <span class="value">{{ item.bomNo || '-' }}</span>
+              <span class="label">物料编号</span>
+              <span class="value">{{ item.productCode || '-' }}</span>
             </div>
             <div class="grid-item">
-              <span class="label">BOM版本</span>
-              <span class="value">{{ item.bomVersion || '-' }}</span>
+              <span class="label">规格型号</span>
+              <span class="value">{{ item.productSpec || '-' }}</span>
             </div>
             <div class="grid-item">
-              <span class="label">执行单单号</span>
-              <span class="value">{{ item.no || '-' }}</span>
-            </div>
-            <div class="grid-item">
-              <span class="label">物料编码</span>
-              <span class="value">{{ item.exeMaterialNumber || '-' }}</span>
-            </div>
-            <div class="grid-item">
-              <span class="label">成品物料编码</span>
-              <span class="value">{{ item.finishMaterialNumber || '-' }}</span>
-            </div>
-            <div class="grid-item">
-              <span class="label">成品物料名称</span>
-              <span class="value">{{ item.finishMaterialName || '-' }}</span>
-            </div>
-            <div class="grid-item">
-              <span class="label">专案号</span>
-              <span class="value">{{ item.mtoNo || '-' }}</span>
+              <span class="label">数量</span>
+              <span class="value highlight">{{ item.productQty }}</span>
             </div>
             <div class="grid-item">
               <span class="label">单位</span>
-              <span class="value">{{ item.unit || '-' }}</span>
+              <span class="value">{{ item.productUnit || '-' }}</span>
             </div>
             <div class="grid-item">
-              <span class="label">图档数量</span>
-              <span class="value highlight">{{ item.drawQty }}</span>
+              <span class="label">仓位编码</span>
+              <span class="value">{{ item.locationCode || '-' }}</span>
             </div>
           </div>
-          <div class="detail-card__footer">
-            <div>
-              <span class="label">是否合格：</span>
-              <van-tag :type="item.isQualified === '1' ? 'success' : 'danger'">
-                {{ item.isQualified === '1' ? '合格' : '不合格' }}
-              </van-tag>
-            </div>
-            <div>
-              <span class="label">异常类型：</span>
-              <span class="value">{{ item.execeptionType || '-' }}</span>
-            </div>
+          <div v-if="item.remark" class="detail-card__footer">
             <div>
               <span class="label">备注：</span>
-              <span class="value">{{ item.remark || '-' }}</span>
+              <span class="value">{{ item.remark }}</span>
             </div>
           </div>
         </div>
@@ -102,7 +78,7 @@ import useInboundOrders from '@/composables/useInboundOrders';
 
 const route = useRoute();
 const router = useRouter();
-const { getOrderById } = useInboundOrders();
+const { getOrderById, resolveStatusMeta } = useInboundOrders();
 
 const order = computed(() => getOrderById(route.params.id));
 
@@ -110,10 +86,7 @@ const status = computed(() => {
   if (!order.value) {
     return { label: '-', type: 'primary' };
   }
-  const hasException = order.value.items.some((item) => item.isQualified === '0');
-  return hasException
-    ? { label: '存在异常', type: 'danger' }
-    : { label: '全部合格', type: 'success' };
+  return resolveStatusMeta(order.value.inStockStatus);
 });
 
 const goBack = () => {


### PR DESCRIPTION
## Summary
- rework the inbound order composable around WMS field names and expose reusable status metadata
- update the inbound order list page to filter by audit states, show warehouse-centric details, and align stats with the new data model
- refresh the create and detail flows to capture/display warehouse, source order, and material line items with Vant components

## Testing
- npm run lint *(fails: existing lint violations across legacy uni-app files)*

------
https://chatgpt.com/codex/tasks/task_e_68faedda94908327b023b0ddb88ac241