### PR TITLE
feat: add Pinia global cache request helper

### DIFF
--- a/src/axios/index.js
+++ b/src/axios/index.js
@@ -1,0 +1,3 @@
+import request from '@/utils/http';
+
+export default request;

--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="dc-select-dialog" :style="{ width }">
+  <div class="dc-select-dialog" :style="{ width, '--dc-select-dialog-footer-height': footerHeight }">
     <div v-if="$slots.default" class="dc-select-dialog__trigger" @click="openPopup">
       <slot></slot>
     </div>
@@ -208,7 +208,10 @@
       </div>
 
       <div class="dc-select-dialog__footer">
-        <van-button block type="primary" @click="confirmSelection">{{ confirmText }}</van-button>
+        <div class="dc-select-dialog__footer-actions">
+          <van-button size="mini" type="default" plain @click="cancelSelection">取消</van-button>
+          <van-button size="mini" type="primary" @click="confirmSelection">{{ confirmText }}</van-button>
+        </div>
       </div>
     </van-popup>
   </div>
@@ -276,6 +279,7 @@ const popupHeight = computed(() => '100vh');
 const popupTitle = computed(() => props.title || model.value?.title || '请选择');
 const confirmText = computed(() => model.value?.submitTitle || '确定');
 const placeholderText = computed(() => props.placeholder || model.value?.placeholder || '请选择');
+const footerHeight = computed(() => '96px');
 
 const keyField = computed(() => props.masterKey || model.value?.rowKey || rowKeyRef.value || 'id');
 const modelColumns = computed(() => (Array.isArray(model.value?.column) ? model.value.column : []));
@@ -651,6 +655,10 @@ function confirmSelection() {
   open.value = false;
 }
 
+function cancelSelection() {
+  open.value = false;
+}
+
 function onSearch(resetFn) {
   if (typeof resetFn === 'function') {
     resetFn();
@@ -934,7 +942,7 @@ function resetSearch(force = false, resetFn) {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: 12px 16px 80px;
+  padding: 12px 16px calc(var(--dc-select-dialog-footer-height, 96px) + 32px + var(--van-safe-area-bottom, 0px));
 }
 
 .dc-select-dialog__pagination :deep(.dc-content .van-pull-refresh) {
@@ -995,10 +1003,19 @@ function resetSearch(force = false, resetFn) {
 }
 
 .dc-select-dialog__footer {
-  padding: 12px 16px 24px;
+  padding: 12px 16px calc(16px + var(--van-safe-area-bottom, 0px));
   border-top: 1px solid #f5f6f7;
   flex-shrink: 0;
   background: #fff;
+}
+
+.dc-select-dialog__footer-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.dc-select-dialog__footer-actions :deep(.van-button) {
+  flex: 1;
 }
 
 .dc-select-dialog__cell-value {

--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -217,7 +217,7 @@ const currentPage = ref(1);
 const cacheStore = useGlobalCacheStore();
 const dictStore = useDictStore();
 
-const popupHeight = computed(() => '85vh');
+const popupHeight = computed(() => '100vh');
 const popupTitle = computed(() => props.title || model.value?.title || '请选择');
 const confirmText = computed(() => model.value?.submitTitle || '确定');
 const placeholderText = computed(() => props.placeholder || model.value?.placeholder || '请选择');
@@ -555,16 +555,20 @@ function resetSearch(force = false) {
 }
 
 .dc-select-dialog__popup {
-  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   box-sizing: border-box;
+  padding: 0;
 }
 
 .dc-select-dialog__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 8px;
+  padding: 16px;
   border-bottom: 1px solid #f5f6f7;
+  flex-shrink: 0;
 }
 
 .dc-select-dialog__title {
@@ -573,11 +577,12 @@ function resetSearch(force = false) {
 }
 
 .dc-select-dialog__body {
+  flex: 1;
   overflow-y: auto;
-  height: calc(85vh - 96px);
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding: 16px;
 }
 
 .dc-select-dialog__search {
@@ -627,8 +632,13 @@ function resetSearch(force = false) {
   flex: 1;
   min-height: 200px;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.dc-select-dialog__list :deep(.van-loading),
+.dc-select-dialog__list :deep(.van-empty) {
+  margin: auto;
 }
 
 .dc-select-dialog__rows {
@@ -672,6 +682,8 @@ function resetSearch(force = false) {
 }
 
 .dc-select-dialog__footer {
-  padding-top: 8px;
+  padding: 12px 16px 16px;
+  border-top: 1px solid #f5f6f7;
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -1,0 +1,677 @@
+<template>
+  <div class="dc-select-dialog" :style="{ width }">
+    <div v-if="$slots.default" class="dc-select-dialog__trigger" @click="openPopup">
+      <slot></slot>
+    </div>
+    <div v-else class="dc-select-dialog__trigger" :class="{ disabled }" @click="openPopup">
+      <div v-if="multiple && displayTags.length" class="dc-select-dialog__tags">
+        <van-tag
+          v-for="tag in displayTags"
+          :key="tag.key"
+          type="primary"
+          size="medium"
+          :color="tagColor"
+          :text-color="tagTextColor"
+          :closeable="clearable"
+          @close.stop="removeTag(tag.key)"
+        >
+          {{ tag.label }}
+        </van-tag>
+      </div>
+      <div v-else-if="!multiple && displayTags.length" class="dc-select-dialog__text">
+        {{ displayTags[0]?.label || '-' }}
+      </div>
+      <div v-else class="dc-select-dialog__placeholder">
+        {{ placeholderText }}
+      </div>
+      <van-icon
+        v-if="clearable && displayTags.length"
+        name="cross"
+        class="dc-select-dialog__clear"
+        @click.stop="clearSelection"
+      />
+      <van-icon name="arrow" class="dc-select-dialog__arrow" />
+    </div>
+
+    <van-popup
+      v-model:show="open"
+      position="bottom"
+      round
+      class="dc-select-dialog__popup"
+      teleport="body"
+      close-icon="close"
+      closeable
+      :style="{ height: popupHeight }"
+      @close="handleClose"
+    >
+      <div class="dc-select-dialog__header">
+        <span class="dc-select-dialog__title">{{ popupTitle }}</span>
+        <van-button size="small" type="primary" @click="confirmSelection">{{ confirmText }}</van-button>
+      </div>
+
+      <div class="dc-select-dialog__body">
+        <div v-if="searchFields.length" class="dc-select-dialog__search">
+          <div
+            v-for="field in searchFields"
+            :key="field.prop"
+            class="dc-select-dialog__search-item"
+          >
+            <label class="dc-select-dialog__search-label">{{ field.label }}</label>
+            <van-field
+              v-model="searchState[field.prop]"
+              :placeholder="field.searchProps?.placeholder || `请输入${field.label}`"
+              clearable
+              @clear="onSearch"
+            />
+          </div>
+          <div class="dc-select-dialog__search-actions">
+            <van-button type="default" size="small" @click="resetSearch">重置</van-button>
+            <van-button type="primary" size="small" @click="onSearch">查询</van-button>
+          </div>
+        </div>
+
+        <div v-if="selectedRows.length" class="dc-select-dialog__selected">
+          <div class="dc-select-dialog__selected-header">
+            <span>已选 {{ selectedRows.length }}</span>
+            <van-button v-if="clearable" text type="danger" size="small" @click="clearSelection">
+              清空
+            </van-button>
+          </div>
+          <div class="dc-select-dialog__selected-tags">
+            <van-tag
+              v-for="row in selectedRows"
+              :key="getKey(row)"
+              type="danger"
+              plain
+              size="small"
+              :closeable="clearable"
+              @close.stop="removeTag(getKey(row))"
+            >
+              {{ getDisplayLabel(row) }}
+            </van-tag>
+          </div>
+        </div>
+
+        <div class="dc-select-dialog__list">
+          <van-loading v-if="loading" size="24px" vertical>加载中...</van-loading>
+          <van-empty v-else-if="!tableData.length" description="暂无数据" />
+          <div v-else class="dc-select-dialog__rows">
+            <div
+              v-for="row in tableData"
+              :key="getKey(row)"
+              class="dc-select-dialog__row"
+              :class="{ active: isSelected(row) }"
+              @click="toggleRow(row)"
+            >
+              <van-checkbox
+                v-if="multiple"
+                :model-value="isSelected(row)"
+                @click.stop="toggleRow(row)"
+              />
+              <van-radio v-else :model-value="isSelected(row)" @click.stop="toggleSingle(row)" />
+              <div class="dc-select-dialog__row-content">
+                <div
+                  v-for="col in modelColumns"
+                  :key="col.prop"
+                  class="dc-select-dialog__cell"
+                >
+                  <span class="dc-select-dialog__cell-label">{{ col.label }}</span>
+                  <span class="dc-select-dialog__cell-value">
+                    <template v-if="col.component === 'dc-view'">
+                      <dc-view
+                        v-model="row[col.prop]"
+                        type="text"
+                        :object-name="col.objectName"
+                        :show-label="col.showKey || col.prop"
+                      />
+                    </template>
+                    <template v-else-if="col.component === 'dc-dict'">
+                      <dc-dict
+                        type="text"
+                        :value="row[col.prop]"
+                        :options="dictMaps[col.dictData]"
+                      />
+                    </template>
+                    <template v-else-if="col.component === 'dc-dict-key'">
+                      <dc-dict
+                        type="text"
+                        :value="row[col.prop]"
+                        :options="dictMaps[col.dictData]"
+                      />
+                    </template>
+                    <template v-else>
+                      {{ formatCell(row, col) }}
+                    </template>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="pageCount > 1" class="dc-select-dialog__footer">
+        <van-pagination
+          v-model="currentPage"
+          :total-items="total"
+          :items-per-page="queryParams.size"
+          mode="simple"
+          @change="handlePageChange"
+        />
+      </div>
+    </van-popup>
+  </div>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch, nextTick, getCurrentInstance } from 'vue';
+import { useGlobalCacheStore } from '@/store/global-cache';
+import { useDictStore } from '@/store/dict';
+import cacheRequest from '@/components/dc-ui/util/request';
+import cacheData from '@/components/dc-ui/constant/cacheData';
+
+defineOptions({ name: 'SelectDialog' });
+
+const props = defineProps({
+  modelValue: { type: [Array, Object, String, Number], default: null },
+  objectName: { type: String, default: '' },
+  placeholder: { type: String, default: '请选择' },
+  width: { type: String, default: '100%' },
+  disabled: { type: Boolean, default: false },
+  clearable: { type: Boolean, default: true },
+  multiple: { type: Boolean, default: true },
+  showValue: { type: Boolean, default: true },
+  showKey: { type: String, default: '' },
+  masterKey: { type: String, default: '' },
+  returnType: { type: String, default: 'array' },
+  dialogWidth: { type: [String, Number], default: '100%' },
+  title: { type: String, default: '' },
+  query: { type: Object, default: () => ({}) },
+  change: { type: Function, default: null },
+  dynamicIndex: { type: [Number, String], default: null },
+  column: { type: Object, default: null },
+  tagColor: { type: String, default: '#ecf5ff' },
+  tagTextColor: { type: String, default: '#1989fa' },
+});
+
+const emit = defineEmits(['update:modelValue', 'change']);
+
+const instance = getCurrentInstance();
+if (instance?.type) {
+  instance.type.dcAliases = ['wf-select-dialog'];
+}
+
+const open = ref(false);
+const loading = ref(false);
+const total = ref(0);
+const tableData = ref([]);
+const selectedRows = ref([]);
+const dictMaps = reactive({});
+const queryParams = reactive({ current: 1, size: 20 });
+const searchState = reactive({});
+const initDefaultSearch = ref(true);
+const model = ref(null);
+const rowKeyRef = ref('id');
+const currentPage = ref(1);
+
+const cacheStore = useGlobalCacheStore();
+const dictStore = useDictStore();
+
+const popupHeight = computed(() => '85vh');
+const popupTitle = computed(() => props.title || model.value?.title || '请选择');
+const confirmText = computed(() => model.value?.submitTitle || '确定');
+const placeholderText = computed(() => props.placeholder || model.value?.placeholder || '请选择');
+
+const keyField = computed(() => props.masterKey || model.value?.rowKey || rowKeyRef.value || 'id');
+const modelColumns = computed(() => (Array.isArray(model.value?.column) ? model.value.column : []));
+const searchFields = computed(() => modelColumns.value.filter((col) => col?.search));
+const pageCount = computed(() => {
+  const size = Number(queryParams.size) || 20;
+  if (!size) return 1;
+  return Math.max(1, Math.ceil(total.value / size));
+});
+
+const displayTags = computed(() => {
+  return selectedRows.value.map((row) => ({
+    key: getKey(row),
+    label: getDisplayLabel(row) || getKey(row) || '-',
+  }));
+});
+
+const dictCodes = computed(() => {
+  const codes = new Set();
+  modelColumns.value.forEach((col) => {
+    if (col?.dictData) codes.add(col.dictData);
+  });
+  return Array.from(codes);
+});
+
+watch(
+  dictCodes,
+  async (codes) => {
+    Object.keys(dictMaps).forEach((key) => {
+      if (!codes.includes(key)) delete dictMaps[key];
+    });
+    if (!codes.length) return;
+    try {
+      const result = await dictStore.getMany(codes);
+      Object.entries(result).forEach(([code, items]) => {
+        dictMaps[code] = items;
+      });
+    } catch (error) {
+      console.error('Failed to load dict data:', error);
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.objectName,
+  (name) => {
+    model.value = cacheData?.[name] || null;
+    if (model.value?.rowKey) {
+      rowKeyRef.value = model.value.rowKey;
+    }
+    queryParams.current = 1;
+    queryParams.size = 20;
+    initDefaultSearch.value = true;
+    if (model.value?.search?.params && initDefaultSearch.value) {
+      Object.assign(queryParams, model.value.search.params);
+    }
+    resetSearch(true);
+  },
+  { immediate: true }
+);
+
+function parseIds(val) {
+  const key = keyField.value;
+  if (Array.isArray(val)) {
+    return val
+      .map((item) => (typeof item === 'object' ? item?.[key] : item))
+      .filter((id) => id !== undefined && id !== null && `${id}` !== '');
+  }
+  if (val && typeof val === 'object') {
+    const id = val?.[key];
+    return id != null ? [id] : [];
+  }
+  if (typeof val === 'string') return val.split(',').filter(Boolean);
+  if (typeof val === 'number') return [`${val}`];
+  return [];
+}
+
+watch(
+  [() => props.modelValue, () => props.objectName],
+  async ([newVal]) => {
+    if (!props.showValue) {
+      if (!newVal || (Array.isArray(newVal) && !newVal.length) || newVal === '') {
+        selectedRows.value = [];
+      }
+      return;
+    }
+    await nextTick();
+    const ids = parseIds(newVal);
+    if (!ids.length || !model.value?.url) {
+      selectedRows.value = [];
+      return;
+    }
+    try {
+      await cacheRequest.getView({
+        url: model.value.url,
+        data: ids,
+        masterKey: keyField.value,
+      });
+      const bucket = cacheStore.globalData[model.value.url] || {};
+      const rows = Array.isArray(bucket) ? bucket : Object.values(bucket);
+      const key = keyField.value;
+      selectedRows.value = ids.map((id) => {
+        const hit = rows.find((item) => `${item?.[key]}` === `${id}`);
+        return hit ? { ...hit } : { [key]: id };
+      });
+    } catch (error) {
+      console.error('Failed to fetch cache data:', error);
+    }
+  },
+  { immediate: true, deep: true }
+);
+
+const multiple = computed(() => props.multiple !== false);
+
+function openPopup() {
+  if (props.disabled) return;
+  open.value = true;
+  fetchData();
+}
+
+function handleClose() {
+  total.value = 0;
+  tableData.value = [];
+  queryParams.current = 1;
+}
+
+async function fetchData() {
+  if (!model.value?.dialogGet) return;
+  loading.value = true;
+  const paginationParams = props.query?.currentPage
+    ? { currentPage: queryParams.current, pageSize: queryParams.size }
+    : {};
+  try {
+    const res = await model.value.dialogGet({
+      ...queryParams,
+      ...(props.query || {}),
+      ...paginationParams,
+      ...searchState,
+    });
+    const callBack = model.value?.callBack
+      ? model.value.callBack(res)
+      : res?.data?.data ?? res?.data ?? {};
+    const records = callBack?.records || [];
+    const list = Array.isArray(records)
+      ? records
+      : Array.isArray(callBack)
+      ? callBack
+      : [];
+    tableData.value = list.map((item) => ({ ...item }));
+    total.value = callBack?.total ?? res?.data?.total ?? list.length;
+    currentPage.value = queryParams.current;
+    syncSelectionFromTable();
+  } catch (error) {
+    console.error(error);
+    tableData.value = [];
+    total.value = 0;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function isSelected(row) {
+  const key = getKey(row);
+  return selectedRows.value.some((item) => getKey(item) === key);
+}
+
+function toggleRow(row) {
+  if (!multiple.value) {
+    toggleSingle(row);
+    return;
+  }
+  const key = getKey(row);
+  const index = selectedRows.value.findIndex((item) => getKey(item) === key);
+  if (index > -1) {
+    selectedRows.value.splice(index, 1);
+  } else {
+    selectedRows.value.push({ ...row });
+  }
+}
+
+function toggleSingle(row) {
+  if (isSelected(row)) {
+    selectedRows.value = [];
+  } else {
+    selectedRows.value = [{ ...row }];
+  }
+}
+
+function removeTag(key) {
+  const index = selectedRows.value.findIndex((item) => getKey(item) === key);
+  if (index > -1) {
+    selectedRows.value.splice(index, 1);
+    applySelection();
+  }
+}
+
+function clearSelection() {
+  selectedRows.value = [];
+  applySelection();
+}
+
+function getKey(row) {
+  const key = keyField.value;
+  return row?.[key] != null ? `${row[key]}` : '';
+}
+
+function syncSelectionFromTable() {
+  if (!selectedRows.value.length || !tableData.value.length) return;
+  const map = new Map(tableData.value.map((row) => [getKey(row), row]));
+  selectedRows.value = selectedRows.value.map((item) => {
+    const key = getKey(item);
+    const hit = map.get(key);
+    return hit ? { ...hit } : item;
+  });
+}
+
+function getDisplayLabel(row) {
+  const labelKey = props.showKey || model.value?.defaultLabel || keyField.value;
+  return row?.[labelKey];
+}
+
+function formatCell(row, column) {
+  const value = row?.[column.prop];
+  if (value === undefined || value === null || value === '') return '-';
+  return value;
+}
+
+function applySelection() {
+  const key = keyField.value;
+  if (multiple.value) {
+    const payload =
+      props.returnType === 'string'
+        ? selectedRows.value
+            .map((item) => item?.[key])
+            .filter((v) => v != null && v !== '')
+            .join(',')
+        : selectedRows.value.map((item) => ({ ...item }));
+    emit('update:modelValue', payload);
+    emit('change', selectedRows.value.map((item) => ({ ...item })));
+    if (typeof props.change === 'function') {
+      props.change({ value: selectedRows.value, column: props.column, index: props.dynamicIndex });
+    }
+  } else {
+    const row = selectedRows.value.length ? selectedRows.value[0] : null;
+    const payload =
+      props.returnType === 'string' ? (row ? row?.[key] ?? null : null) : row ? { ...row } : null;
+    emit('update:modelValue', payload);
+    emit('change', row ? { ...row } : null);
+    if (typeof props.change === 'function') {
+      props.change({ value: row, column: props.column, index: props.dynamicIndex });
+    }
+  }
+}
+
+function confirmSelection() {
+  applySelection();
+  open.value = false;
+}
+
+function handlePageChange(page) {
+  currentPage.value = page;
+  queryParams.current = page;
+  fetchData();
+}
+
+function onSearch() {
+  queryParams.current = 1;
+  fetchData();
+}
+
+function resetSearch(force = false) {
+  if (!force && !searchFields.value.length) return;
+  Object.keys(searchState).forEach((key) => {
+    delete searchState[key];
+  });
+  searchFields.value.forEach((field) => {
+    searchState[field.prop] = '';
+  });
+  if (force && model.value?.search?.params && initDefaultSearch.value) {
+    Object.assign(searchState, model.value.search.params);
+    initDefaultSearch.value = false;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dc-select-dialog {
+  width: 100%;
+}
+
+.dc-select-dialog__trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #ebedf0;
+  border-radius: 6px;
+  color: #323233;
+  position: relative;
+  flex-wrap: wrap;
+  &.disabled {
+    opacity: 0.6;
+  }
+}
+
+.dc-select-dialog__tags {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dc-select-dialog__text {
+  flex: 1;
+}
+
+.dc-select-dialog__placeholder {
+  flex: 1;
+  color: #969799;
+}
+
+.dc-select-dialog__clear,
+.dc-select-dialog__arrow {
+  color: #c8c9cc;
+}
+
+.dc-select-dialog__clear {
+  margin-left: auto;
+}
+
+.dc-select-dialog__popup {
+  padding: 12px 16px 16px;
+  box-sizing: border-box;
+}
+
+.dc-select-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #f5f6f7;
+}
+
+.dc-select-dialog__title {
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.dc-select-dialog__body {
+  overflow-y: auto;
+  height: calc(85vh - 96px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dc-select-dialog__search {
+  background: #f7f8fa;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.dc-select-dialog__search-item + .dc-select-dialog__search-item {
+  margin-top: 8px;
+}
+
+.dc-select-dialog__search-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 12px;
+  color: #646566;
+}
+
+.dc-select-dialog__search-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dc-select-dialog__selected {
+  background: #fff7e6;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.dc-select-dialog__selected-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.dc-select-dialog__selected-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dc-select-dialog__list {
+  flex: 1;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dc-select-dialog__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.dc-select-dialog__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #f1f2f3;
+  &.active {
+    border-color: var(--van-primary-color, #1989fa);
+    box-shadow: 0 0 0 2px rgba(25, 137, 250, 0.1);
+  }
+}
+
+.dc-select-dialog__row-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dc-select-dialog__cell {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #323233;
+}
+
+.dc-select-dialog__cell-label {
+  color: #969799;
+  margin-right: 8px;
+}
+
+.dc-select-dialog__footer {
+  padding-top: 8px;
+}
+</style>

--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -711,6 +711,18 @@ function resetSearch(force = false, resetFn) {
   flex-wrap: nowrap;
 }
 
+.dc-select-dialog__tags :deep(.van-tag),
+.dc-select-dialog__selected-tags :deep(.van-tag) {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.dc-select-dialog__tags :deep(.van-tag__text),
+.dc-select-dialog__selected-tags :deep(.van-tag__text) {
+  white-space: nowrap;
+}
+
 .dc-select-dialog__text {
   flex: 1;
 }

--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -972,22 +972,26 @@ function resetSearch(force = false, resetFn) {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
+  min-width: 0;
 }
 
 .dc-select-dialog__cell {
   display: flex;
-  flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 6px;
   font-size: 13px;
   color: #323233;
   text-align: left;
+  flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .dc-select-dialog__cell-label {
   color: #969799;
   font-size: 12px;
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .dc-select-dialog__footer {
@@ -1000,6 +1004,9 @@ function resetSearch(force = false, resetFn) {
 .dc-select-dialog__cell-value {
   color: #323233;
   width: 100%;
-  word-break: break-word;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/dc-ui/components/SelectSingle/index.vue
+++ b/src/components/dc-ui/components/SelectSingle/index.vue
@@ -1,0 +1,717 @@
+<template>
+  <div class="dc-select-single" :style="{ width }">
+    <van-field
+      :model-value="displayLabel"
+      :placeholder="placeholderText"
+      :disabled="disabled"
+      readonly
+      clickable
+      is-link
+      class="dc-select-single__trigger"
+      @click="openPopup"
+    >
+      <template #right-icon>
+        <van-icon
+          v-if="clearable && !disabled && displayLabel"
+          name="cross"
+          class="dc-select-single__clear"
+          @click.stop="clearValue"
+        />
+      </template>
+    </van-field>
+
+    <van-popup
+      v-model:show="open"
+      position="bottom"
+      round
+      class="dc-select-single__popup"
+      teleport="body"
+      :style="{ height: popupHeight }"
+      @close="handleClose"
+    >
+      <div class="dc-select-single__header">
+        <span class="dc-select-single__title">{{ popupTitle }}</span>
+        <van-icon name="cross" class="dc-select-single__close" @click="closePopup" />
+      </div>
+
+      <div class="dc-select-single__body" :class="{ 'is-loading': loading }">
+        <div v-if="loading" class="dc-select-single__loading">
+          <van-loading size="24px">加载中...</van-loading>
+        </div>
+
+        <DcPagination
+          ref="pagerRef"
+          class="dc-select-single__pagination"
+          :fetcher="paginationFetcher"
+          :page-size="pageSize"
+          :offset="120"
+          :add-visible="false"
+          :immediate="false"
+          :back-top-threshold="Infinity"
+          :get-nav-el="getNavElement"
+        >
+          <template #sticky="{ resetAndLoad }">
+            <div v-if="searchFields.length" class="dc-select-single__search">
+              <div class="dc-select-single__search-fields">
+                <van-field
+                  v-for="field in searchFields"
+                  :key="field.prop"
+                  v-model="searchState[field.prop]"
+                  :label="field.label"
+                  :placeholder="field.searchProps?.placeholder || `请输入${field.label}`"
+                  clearable
+                  label-width="auto"
+                  @keyup.enter="resetAndLoad()"
+                  @clear="resetAndLoad()"
+                />
+              </div>
+              <div class="dc-select-single__search-actions">
+                <van-button type="default" size="small" plain @click="() => resetSearch(resetAndLoad)">
+                  重置
+                </van-button>
+                <van-button type="primary" size="small" @click="resetAndLoad">
+                  查询
+                </van-button>
+              </div>
+            </div>
+          </template>
+
+          <template #item="{ item }">
+            <div
+              class="dc-select-single__row"
+              :class="{ active: isDraftSelected(item) }"
+              @click="selectDraft(item)"
+            >
+              <van-radio :model-value="isDraftSelected(item)" @click.stop="selectDraft(item)" />
+              <div class="dc-select-single__row-content">
+                <div v-for="col in modelColumns" :key="col.prop" class="dc-select-single__cell">
+                  <span class="dc-select-single__cell-label">{{ col.label }}</span>
+                  <div class="dc-select-single__cell-value">
+                    <template v-if="col.component === 'dc-view'">
+                      <dc-view
+                        v-model="item[col.prop]"
+                        type="text"
+                        :object-name="col.objectName"
+                        :show-label="col.showKey || col.prop"
+                      />
+                    </template>
+                    <template v-else-if="col.component === 'dc-dict'">
+                      <dc-dict type="text" :value="item[col.prop]" :options="dictMaps[col.dictData]" />
+                    </template>
+                    <template v-else-if="col.component === 'dc-dict-key'">
+                      <dc-dict-key type="text" :value="item[col.prop]" :options="dictMaps[col.dictData]" />
+                    </template>
+                    <template v-else>
+                      {{ formatCell(item, col) }}
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <template #empty>
+            <van-empty description="暂无数据" />
+          </template>
+        </DcPagination>
+      </div>
+
+      <div class="dc-select-single__footer">
+        <van-button size="mini" type="default" plain @click="cancelSelection">取消</van-button>
+        <van-button size="mini" type="primary" @click="confirmSelection">{{ confirmText }}</van-button>
+      </div>
+    </van-popup>
+  </div>
+</template>
+
+<script setup>
+import { computed, getCurrentInstance, nextTick, reactive, ref, watch } from 'vue';
+import DcPagination from '@/components/dc-ui/components/Pagination/index.vue';
+import cacheData from '@/components/dc-ui/constant/cacheData';
+import cacheRequest from '@/components/dc-ui/util/request';
+import { useGlobalCacheStore } from '@/store/global-cache';
+import { useDictStore } from '@/store/dict';
+
+defineOptions({ name: 'SelectSingle' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Object, null], default: null },
+  objectName: { type: String, default: '' },
+  placeholder: { type: String, default: '请选择' },
+  width: { type: String, default: '100%' },
+  disabled: { type: Boolean, default: false },
+  clearable: { type: Boolean, default: true },
+  title: { type: String, default: '' },
+  dialogWidth: { type: [String, Number], default: '100%' },
+  query: { type: Object, default: () => ({}) },
+  change: { type: Function, default: null },
+  dynamicIndex: { type: [Number, String], default: null },
+  column: { type: Object, default: null },
+  showValue: { type: Boolean, default: true },
+  showKey: { type: String, default: '' },
+  masterKey: { type: String, default: '' },
+  returnType: { type: String, default: 'label' },
+});
+
+const emit = defineEmits(['update:modelValue', 'change']);
+
+const instance = getCurrentInstance();
+if (instance?.type) {
+  instance.type.dcAliases = ['select-single'];
+}
+
+const open = ref(false);
+const loading = ref(false);
+const pagerRef = ref(null);
+const pageSize = ref(20);
+const model = ref(null);
+const rowKeyRef = ref('id');
+const initDefaultSearch = ref(true);
+const searchState = reactive({});
+const dictMaps = reactive({});
+const selectedRow = ref(null);
+const draftRow = ref(null);
+const manualLabel = ref('');
+
+const cacheStore = useGlobalCacheStore();
+const dictStore = useDictStore();
+const zeroNavEl = { getBoundingClientRect: () => ({ height: 0 }) };
+const getNavElement = () => zeroNavEl;
+
+const popupHeight = computed(() => '100vh');
+const keyField = computed(() => props.masterKey || model.value?.rowKey || rowKeyRef.value || 'id');
+const labelField = computed(() => props.showKey || model.value?.defaultLabel || keyField.value);
+const modelColumns = computed(() => (Array.isArray(model.value?.column) ? model.value.column : []));
+const searchFields = computed(() => modelColumns.value.filter((col) => col?.search));
+
+const popupTitle = computed(() => props.title || model.value?.title || '请选择');
+const confirmText = computed(() => model.value?.submitTitle || '确定');
+const placeholderText = computed(() => props.placeholder || model.value?.placeholder || '请选择');
+
+const displayLabel = computed(() => {
+  if (!props.showValue) return '';
+  if (selectedRow.value) {
+    return getDisplayLabel(selectedRow.value);
+  }
+  return manualLabel.value || '';
+});
+
+const dictCodes = computed(() => {
+  const codes = new Set();
+  modelColumns.value.forEach((col) => {
+    if (col?.dictData) codes.add(col.dictData);
+  });
+  return Array.from(codes);
+});
+
+watch(
+  dictCodes,
+  async (codes) => {
+    Object.keys(dictMaps).forEach((key) => {
+      if (!codes.includes(key)) delete dictMaps[key];
+    });
+    if (!codes.length) return;
+    try {
+      const result = await dictStore.getMany(codes);
+      Object.entries(result).forEach(([code, items]) => {
+        dictMaps[code] = items;
+      });
+    } catch (error) {
+      console.error('Failed to load dict data:', error);
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.objectName,
+  (name) => {
+    model.value = cacheData?.[name] || null;
+    if (model.value?.rowKey) {
+      rowKeyRef.value = model.value.rowKey;
+    }
+    const sizeFromModel =
+      Number(model.value?.search?.params?.size ?? model.value?.pageSize ?? 0) || 20;
+    pageSize.value = sizeFromModel;
+    initDefaultSearch.value = true;
+    resetSearch(true);
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.modelValue,
+  async (value) => {
+    if (!props.showValue) {
+      if (!value) {
+        selectedRow.value = null;
+        manualLabel.value = '';
+      }
+      return;
+    }
+
+    if (value === null || value === undefined || value === '') {
+      selectedRow.value = null;
+      manualLabel.value = '';
+      return;
+    }
+
+    if (typeof value === 'object') {
+      selectedRow.value = { ...value };
+      manualLabel.value = getDisplayLabel(value);
+      return;
+    }
+
+    const id = `${value}`;
+    if (!model.value?.url) {
+      selectedRow.value = null;
+      manualLabel.value = id;
+      return;
+    }
+
+    try {
+      await cacheRequest.getView({ url: model.value.url, data: [id], masterKey: keyField.value });
+      const bucket = cacheStore.globalData[model.value.url] || {};
+      const rows = Array.isArray(bucket) ? bucket : Object.values(bucket);
+      const key = keyField.value;
+      const found = rows.find((item) => `${item?.[key]}` === id);
+      if (found) {
+        selectedRow.value = { ...found };
+        manualLabel.value = getDisplayLabel(found);
+      } else {
+        selectedRow.value = null;
+        manualLabel.value = id;
+      }
+    } catch (error) {
+      console.error('Failed to fetch cache data:', error);
+      selectedRow.value = null;
+      manualLabel.value = id;
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => selectedRow.value,
+  (row) => {
+    if (!row) return;
+    draftRow.value = { ...row };
+  }
+);
+
+function openPopup() {
+  if (props.disabled) return;
+  open.value = true;
+  draftRow.value = selectedRow.value ? { ...selectedRow.value } : null;
+  nextTick(() => {
+    pagerRef.value?.resetAndLoad?.();
+  });
+}
+
+function closePopup() {
+  open.value = false;
+}
+
+function handleClose() {
+  loading.value = false;
+}
+
+function cancelSelection() {
+  draftRow.value = selectedRow.value ? { ...selectedRow.value } : null;
+  closePopup();
+}
+
+function confirmSelection() {
+  const row = draftRow.value ? { ...draftRow.value } : null;
+  selectedRow.value = row;
+  manualLabel.value = row ? getDisplayLabel(row) : '';
+
+  const key = keyField.value;
+  let payload = null;
+  if (row) {
+    if (props.returnType === 'id') {
+      payload = row?.[key] ?? null;
+    } else if (props.returnType === 'object') {
+      payload = { ...row };
+    } else {
+      payload = getDisplayLabel(row);
+    }
+  } else if (props.returnType === 'label') {
+    payload = '';
+  }
+
+  emit('update:modelValue', payload);
+  emit('change', row);
+  if (typeof props.change === 'function') {
+    props.change({ value: row, column: props.column, index: props.dynamicIndex });
+  }
+  closePopup();
+}
+
+function clearValue() {
+  selectedRow.value = null;
+  draftRow.value = null;
+  manualLabel.value = '';
+  emit('update:modelValue', props.returnType === 'object' ? null : '');
+  emit('change', null);
+  if (typeof props.change === 'function') {
+    props.change({ value: null, column: props.column, index: props.dynamicIndex });
+  }
+}
+
+function resetSearch(force = false, reloadFn) {
+  if (!force && !searchFields.value.length) return;
+  Object.keys(searchState).forEach((key) => {
+    delete searchState[key];
+  });
+  searchFields.value.forEach((field) => {
+    searchState[field.prop] = '';
+  });
+  if (force && model.value?.search?.params && initDefaultSearch.value) {
+    Object.assign(searchState, model.value.search.params);
+    initDefaultSearch.value = false;
+  } else if (!force && typeof reloadFn === 'function') {
+    reloadFn();
+  }
+}
+
+function getKey(row) {
+  const key = keyField.value;
+  return row?.[key] != null ? `${row[key]}` : '';
+}
+
+function getDisplayLabel(row) {
+  if (!row) return '';
+  const labelKey = labelField.value;
+  const value = row?.[labelKey];
+  if (value !== undefined && value !== null && `${value}` !== '') {
+    return value;
+  }
+  const fallbackKey = modelColumns.value?.[0]?.prop;
+  if (fallbackKey && row?.[fallbackKey] != null && `${row[fallbackKey]}` !== '') {
+    return row[fallbackKey];
+  }
+  return row?.[keyField.value] ?? '';
+}
+
+function formatCell(row, column) {
+  const value = row?.[column.prop];
+  if (value === undefined || value === null || value === '') return '-';
+  return value;
+}
+
+function isDraftSelected(row) {
+  const draftKey = draftRow.value ? getKey(draftRow.value) : '';
+  return draftKey && draftKey === getKey(row);
+}
+
+function selectDraft(row) {
+  if (isDraftSelected(row)) {
+    draftRow.value = null;
+  } else {
+    draftRow.value = { ...row };
+  }
+}
+
+function syncDraftWithRecords(records) {
+  if (!Array.isArray(records) || !records.length) return;
+  const key = keyField.value;
+  const draftKey = draftRow.value?.[key];
+  if (draftKey != null) {
+    const hit = records.find((item) => `${item?.[key]}` === `${draftKey}`);
+    if (hit) {
+      draftRow.value = { ...hit };
+      return;
+    }
+  }
+  if (!draftRow.value && manualLabel.value) {
+    const labelKey = labelField.value;
+    const hit = records.find((item) => `${item?.[labelKey]}` === manualLabel.value);
+    if (hit) {
+      draftRow.value = { ...hit };
+    }
+  }
+}
+
+function normalizeResponse(res, fallbackPageNo, fallbackSize) {
+  const raw = model.value?.callBack ? model.value.callBack(res) : res?.data?.data ?? res?.data ?? {};
+  let records = [];
+  let total = 0;
+  let current = fallbackPageNo;
+  let pages;
+  let size = fallbackSize;
+
+  if (Array.isArray(raw)) {
+    records = raw;
+    total = raw.length;
+  } else if (raw && typeof raw === 'object') {
+    if (Array.isArray(raw.records)) {
+      records = raw.records;
+    } else if (Array.isArray(raw.list)) {
+      records = raw.list;
+    } else if (Array.isArray(raw.rows)) {
+      records = raw.rows;
+    }
+
+    total =
+      raw.total ??
+      raw.count ??
+      raw.totalCount ??
+      raw.recordsTotal ??
+      (Array.isArray(records) ? records.length : 0);
+    current = raw.current ?? raw.pageNo ?? raw.page ?? raw.currentPage ?? current;
+    pages = raw.pages ?? raw.pageCount ?? raw.totalPage ?? raw.pagesCount;
+    size = raw.size ?? raw.pageSize ?? raw.limit ?? size;
+  }
+
+  const normalizedRecords = Array.isArray(records) ? records.map((item) => ({ ...item })) : [];
+  if (!pages && typeof total === 'number' && total > 0 && typeof size === 'number' && size > 0) {
+    pages = Math.ceil(total / size);
+  }
+  if (!pages && total === 0 && normalizedRecords.length > 0 && typeof size === 'number' && size > 0) {
+    pages = normalizedRecords.length < size ? 1 : undefined;
+  }
+
+  return {
+    records: normalizedRecords,
+    total,
+    current,
+    pages,
+    size,
+  };
+}
+
+async function paginationFetcher({ pageNo, pageSize: sizeParam }) {
+  if (!model.value?.dialogGet) {
+    return { current: pageNo, pages: 0, total: 0, size: sizeParam || pageSize.value, records: [] };
+  }
+
+  const size = Number(sizeParam || pageSize.value || 20) || 20;
+  if (pageNo === 1) {
+    loading.value = true;
+  }
+
+  const paginationParams = props.query?.currentPage
+    ? { currentPage: pageNo, pageSize: size }
+    : { current: pageNo, size };
+  const requestPayload = {
+    ...(model.value?.defaultParams || {}),
+    ...(props.query || {}),
+    ...paginationParams,
+    ...searchState,
+  };
+
+  try {
+    const response = await model.value.dialogGet(requestPayload);
+    const normalized = normalizeResponse(response, pageNo, size);
+    if (typeof normalized.size === 'number' && normalized.size > 0 && normalized.size !== pageSize.value) {
+      pageSize.value = normalized.size;
+    }
+    syncDraftWithRecords(normalized.records);
+    return {
+      current: normalized.current ?? pageNo,
+      pages: normalized.pages,
+      total:
+        typeof normalized.total === 'number' && normalized.total > 0
+          ? normalized.total
+          : normalized.records.length,
+      size: normalized.size ?? size,
+      records: normalized.records,
+    };
+  } catch (error) {
+    console.error('Failed to fetch dialog data:', error);
+    throw error;
+  } finally {
+    if (pageNo === 1) {
+      loading.value = false;
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.dc-select-single {
+  width: 100%;
+}
+
+.dc-select-single__trigger {
+  --van-field-padding: 10px 12px;
+  --van-field-label-width: 80px;
+  :deep(.van-field__control) {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.dc-select-single__clear {
+  color: #c8c9cc;
+  font-size: 16px;
+}
+
+.dc-select-single__popup {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.dc-select-single__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid #f5f6f7;
+  flex-shrink: 0;
+}
+
+.dc-select-single__title {
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.dc-select-single__close {
+  color: #969799;
+  font-size: 18px;
+}
+
+.dc-select-single__body {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.dc-select-single__body.is-loading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 1;
+}
+
+.dc-select-single__loading {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.dc-select-single__pagination {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.dc-select-single__pagination :deep(.dc-sticky-header) {
+  position: sticky !important;
+  top: 0 !important;
+  left: 0;
+  right: 0;
+  background: #fff;
+  padding: 12px 16px 8px;
+  border-bottom: 1px solid #f5f6f7;
+  box-shadow: none;
+}
+
+.dc-select-single__search {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dc-select-single__search-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.dc-select-single__search-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.dc-select-single__pagination :deep(.dc-content) {
+  position: relative !important;
+  top: 0 !important;
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px calc(16px + var(--van-safe-area-bottom, 0px) + 64px);
+}
+
+.dc-select-single__pagination :deep(.van-pull-refresh) {
+  min-height: 100%;
+}
+
+.dc-select-single__pagination :deep(.dc-back-top),
+.dc-select-single__pagination :deep(.dc-fab-add) {
+  display: none !important;
+}
+
+.dc-select-single__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #f1f2f3;
+  margin-bottom: 8px;
+  &.active {
+    border-color: var(--van-primary-color, #1989fa);
+    box-shadow: 0 0 0 2px rgba(25, 137, 250, 0.1);
+  }
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.dc-select-single__row-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.dc-select-single__cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #323233;
+  white-space: nowrap;
+}
+
+.dc-select-single__cell-label {
+  color: #969799;
+  font-size: 12px;
+  flex: 0 0 auto;
+}
+
+.dc-select-single__cell-value {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dc-select-single__footer {
+  padding: 12px 16px calc(16px + var(--van-safe-area-bottom, 0px));
+  border-top: 1px solid #f5f6f7;
+  display: flex;
+  gap: 12px;
+  flex-shrink: 0;
+  background: #fff;
+}
+
+.dc-select-single__footer :deep(.van-button) {
+  flex: 1;
+}
+</style>

--- a/src/components/dc-ui/components/View/index.vue
+++ b/src/components/dc-ui/components/View/index.vue
@@ -23,9 +23,9 @@
 
 <script setup>
 import { reactive, toRefs, watch, computed } from 'vue';
+import cacheRequest from './../../util/request';
 // import ComponentApi from './../../api/index';
-// import store from '@/store/';
-// import cacheData from './../../constant/cacheData';
+import cacheData from './../../constant/cacheData';
 
 const props = defineProps({
   // 展示类型：'text' | 'tag'
@@ -79,15 +79,13 @@ watch(
       }
 
       // 触发缓存/视图接口预取（维持你的原始逻辑）
-      await ComponentApi.cache.getView({
+      const viewData = await cacheRequest.getView({
         url: componentData.currentObject.url,
         data: ids,
       });
 
-      const currentGlobalData = store.getters?.globalData?.[componentData.currentObject.url] || {};
-
       // 将 id 映射为对象（或保留原始 id）
-      componentData.iptTagData = ids.map((id) => currentGlobalData[id] ?? id);
+      componentData.iptTagData = Array.isArray(viewData) ? viewData : [];
     } catch (error) {
       console.error(error);
       componentData.iptTagData = [];

--- a/src/components/dc-ui/index.js
+++ b/src/components/dc-ui/index.js
@@ -38,6 +38,12 @@ export default {
     Object.entries(dcComponents).forEach(([tag, comp]) => {
       const finalTag = prefix === 'dc-' ? tag : tag.replace(/^dc-/, prefix);
       app.component(finalTag, comp);
+      const aliases = Array.isArray(comp.dcAliases) ? comp.dcAliases : [];
+      aliases.forEach((alias) => {
+        if (typeof alias === 'string' && alias) {
+          app.component(alias, comp);
+        }
+      });
     });
   },
 };

--- a/src/components/dc-ui/util/request.js
+++ b/src/components/dc-ui/util/request.js
@@ -1,0 +1,17 @@
+import { useGlobalCacheStore } from '@/store/global-cache';
+
+function getStore() {
+  return useGlobalCacheStore();
+}
+
+export default {
+  getView(payload) {
+    return getStore().getView(payload);
+  },
+  getQuery(payload) {
+    return getStore().getQuery(payload);
+  },
+  getList(payload) {
+    return getStore().getList(payload);
+  },
+};

--- a/src/store/global-cache.js
+++ b/src/store/global-cache.js
@@ -1,0 +1,130 @@
+import { defineStore } from 'pinia';
+import request from '@/utils/http';
+
+const toKey = (id) => (id == null ? '' : String(id));
+
+export const useGlobalCacheStore = defineStore('global-cache', {
+  state: () => ({
+    globalData: {},
+    queue: {},
+  }),
+  actions: {
+    _ensureBucket(url) {
+      if (!url) throw new Error('url is required');
+      if (!this.globalData[url]) {
+        this.globalData[url] = {};
+      }
+      return this.globalData[url];
+    },
+    _ensureQueue(url) {
+      if (!this.queue[url]) {
+        this.queue[url] = {
+          data: [],
+          timer: null,
+          promises: [],
+        };
+      }
+      return this.queue[url];
+    },
+    _resolvePromises(url, promises) {
+      const bucket = this.globalData[url] || {};
+      promises.forEach(({ resolve, data }) => {
+        const ids = Array.isArray(data) ? data : [];
+        const payload = ids.map((id) => {
+          const key = toKey(id);
+          return bucket[key] || { id };
+        });
+        resolve(payload);
+      });
+    },
+    _rejectPromises(error, promises) {
+      promises.forEach(({ reject }) => reject(error));
+    },
+    async getView({ url, data = [], masterKey }) {
+      const ids = Array.isArray(data) ? data : [];
+      const bucket = this._ensureBucket(url);
+      const queueItem = this._ensureQueue(url);
+
+      const existingKeys = new Set(Object.keys(bucket));
+      const queuedKeys = new Set(queueItem.data.map((id) => toKey(id)));
+
+      ids.forEach((id) => {
+        const key = toKey(id);
+        if (key && !existingKeys.has(key) && !queuedKeys.has(key)) {
+          queueItem.data.push(id);
+          queuedKeys.add(key);
+        }
+      });
+
+      return new Promise((resolve, reject) => {
+        queueItem.promises.push({ resolve, reject, data: ids.slice() });
+        if (!queueItem.timer) {
+          queueItem.timer = setTimeout(async () => {
+            const pendingData = queueItem.data.slice();
+            const pendingPromises = queueItem.promises.slice();
+            clearTimeout(queueItem.timer);
+            delete this.queue[url];
+
+            try {
+              if (pendingData.length) {
+                const res = await request({
+                  url,
+                  method: 'post',
+                  data: pendingData,
+                });
+                const { code, data: responseData } = res.data || {};
+                if (code !== 200) {
+                  throw new Error(`Request failed with code: ${code}`);
+                }
+                (Array.isArray(responseData) ? responseData : []).forEach((item) => {
+                  const key = masterKey ? item?.[masterKey] : item?.id;
+                  if (key != null) {
+                    bucket[toKey(key)] = item;
+                  }
+                });
+              }
+              this._resolvePromises(url, pendingPromises);
+            } catch (error) {
+              this._rejectPromises(error, pendingPromises);
+            }
+          }, 300);
+        }
+      });
+    },
+    async getQuery({ url, params }) {
+      const bucket = this._ensureBucket(url);
+      const res = await request({
+        url,
+        method: 'post',
+        params,
+      });
+      const { code, data: responseData } = res.data || {};
+      if (code === 200) {
+        (Array.isArray(responseData) ? responseData : []).forEach((item) => {
+          if (item?.id != null) {
+            bucket[toKey(item.id)] = item;
+          }
+        });
+      }
+      return res;
+    },
+    async getList({ url, params }) {
+      const bucket = this._ensureBucket(url);
+      const res = await request({
+        url,
+        method: 'post',
+        params,
+      });
+      const { code, data: responseData } = res.data || {};
+      if (code === 200) {
+        (Array.isArray(responseData) ? responseData : []).forEach((item) => {
+          if (item?.id != null) {
+            bucket[toKey(item.id)] = item;
+          }
+        });
+        return responseData;
+      }
+      return [];
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a Pinia store that centralises global cache data and batched requests
- expose the cache store through the dc-ui request helper and refresh the view component to consume it
- add the axios alias entry point so existing imports keep working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc257e0918832782ff5a4c40e23cde