### PR TITLE
feat: add Vant site planning create page

### DIFF
--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -48,7 +48,7 @@ export default {
       path: 'site-planning',
       name: 'appsSitePlanning',
       meta: { title: '现场计划单', requiresAuth: true },
-      component: () => import('@/views/apps/SitePlanning.vue'),
+      component: () => import('@/views/apps/SitePlanning/Create.vue'),
     },
     {
       path: 'work-report',

--- a/src/views/apps/SitePlanning.vue
+++ b/src/views/apps/SitePlanning.vue
@@ -1,7 +1,0 @@
-<template>
-  <AppPage title="现场计划单" />
-</template>
-
-<script setup>
-import AppPage from './components/AppPage.vue';
-</script>

--- a/src/views/apps/SitePlanning/Create.vue
+++ b/src/views/apps/SitePlanning/Create.vue
@@ -5,26 +5,36 @@
     <div class="base-wrapper mtop20">
       <div class="title">{{ form.orderCode || '-' }}</div>
       <div class="baseinfo">
-        <van-cell-group inset>
-          <van-field label="阶段编码" :model-value="form.phaseCode || ''" readonly />
-          <van-field label="阶段名称" :model-value="form.phaseName || ''" readonly />
-          <van-field label="开始时间" :model-value="form.startDate || ''" readonly />
-          <van-field label="结束时间" :model-value="form.endDate || ''" readonly />
-          <van-field
-            v-model="form.overdueExplanation"
-            label="延期说明"
-            type="textarea"
-            rows="2"
-            autosize
-            maxlength="200"
-            show-word-limit
-            placeholder="请输入"
-          />
-        </van-cell-group>
+        <van-card class="info-card" :border="false">
+          <template #title>
+            <div class="info-card__title">基础信息</div>
+          </template>
 
-        <van-button block type="primary" class="save-btn" :loading="submitting" @click="handleSave">
-          保存
-        </van-button>
+          <template #desc>
+            <van-cell-group>
+              <van-field label="阶段编码" :model-value="form.phaseCode || ''" readonly />
+              <van-field label="阶段名称" :model-value="form.phaseName || ''" readonly />
+              <van-field label="开始时间" :model-value="form.startDate || ''" readonly />
+              <van-field label="结束时间" :model-value="form.endDate || ''" readonly />
+              <van-field
+                v-model="form.overdueExplanation"
+                label="延期说明"
+                type="textarea"
+                rows="2"
+                autosize
+                maxlength="200"
+                show-word-limit
+                placeholder="请输入"
+              />
+            </van-cell-group>
+          </template>
+
+          <template #footer>
+            <van-button block type="primary" class="save-btn" :loading="submitting" @click="handleSave">
+              保存
+            </van-button>
+          </template>
+        </van-card>
       </div>
     </div>
   </div>
@@ -68,7 +78,6 @@ async function fetchDetail() {
       phaseName: '',
       startDate: '',
       endDate: '',
-      overdueExplanation: '',
       ...data,
       overdueExplanation: data?.overdueExplanation ?? '',
     });
@@ -140,11 +149,41 @@ async function handleSave() {
     box-sizing: border-box;
 
     .baseinfo {
-      padding: 32rpx 24rpx 48rpx;
+      padding-bottom: 48rpx;
       box-sizing: border-box;
-      border-radius: 20rpx;
-      background-color: #fff;
-      position: relative;
+
+      .info-card {
+        --van-card-background: #fff;
+        border-radius: 20rpx;
+        overflow: hidden;
+        box-shadow: 0 6rpx 20rpx rgba(0, 0, 0, 0.08);
+
+        :deep(.van-card__header) {
+          padding: 32rpx 24rpx 0;
+        }
+
+        :deep(.van-card__content) {
+          padding: 0 24rpx 32rpx;
+        }
+
+        :deep(.van-card__desc) {
+          margin-top: 24rpx;
+        }
+
+        :deep(.van-cell-group) {
+          background-color: transparent;
+        }
+
+        :deep(.van-card__footer) {
+          padding: 0 24rpx 32rpx;
+        }
+      }
+
+      .info-card__title {
+        font-size: 28rpx;
+        font-weight: 600;
+        color: #222;
+      }
 
       .save-btn {
         margin-top: 32rpx;

--- a/src/views/apps/SitePlanning/Create.vue
+++ b/src/views/apps/SitePlanning/Create.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="site-planning-create">
+    <dc-nav-bar title="现场计划单" fixed left-arrow @click-left="handleBack" />
+
+    <div class="base-wrapper mtop20">
+      <div class="title">{{ form.orderCode || '-' }}</div>
+      <div class="baseinfo">
+        <van-cell-group inset>
+          <van-field label="阶段编码" :model-value="form.phaseCode || ''" readonly />
+          <van-field label="阶段名称" :model-value="form.phaseName || ''" readonly />
+          <van-field label="开始时间" :model-value="form.startDate || ''" readonly />
+          <van-field label="结束时间" :model-value="form.endDate || ''" readonly />
+          <van-field
+            v-model="form.overdueExplanation"
+            label="延期说明"
+            type="textarea"
+            rows="2"
+            autosize
+            maxlength="200"
+            show-word-limit
+            placeholder="请输入"
+          />
+        </van-cell-group>
+
+        <van-button block type="primary" class="save-btn" :loading="submitting" @click="handleSave">
+          保存
+        </van-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { showToast, showConfirmDialog } from 'vant';
+
+import Api from '@/api';
+
+const route = useRoute();
+const router = useRouter();
+
+const form = reactive({
+  orderCode: '',
+  phaseCode: '',
+  phaseName: '',
+  startDate: '',
+  endDate: '',
+  overdueExplanation: '',
+});
+
+const submitting = ref(false);
+
+onMounted(() => {
+  fetchDetail();
+});
+
+async function fetchDetail() {
+  const id = route.query?.id;
+  if (!id) return;
+
+  try {
+    const res = await Api.application.planSheep.detail({ id });
+    const data = res?.data?.data ?? res?.data ?? {};
+    Object.assign(form, {
+      orderCode: '',
+      phaseCode: '',
+      phaseName: '',
+      startDate: '',
+      endDate: '',
+      overdueExplanation: '',
+      ...data,
+      overdueExplanation: data?.overdueExplanation ?? '',
+    });
+  } catch (error) {
+    console.error(error);
+    showToast('获取详情失败');
+  }
+}
+
+function handleBack() {
+  router.back();
+}
+
+async function handleSave() {
+  if (submitting.value) return;
+
+  try {
+    await showConfirmDialog({
+      title: '提示',
+      message: '确认保存吗',
+    });
+  } catch {
+    return;
+  }
+
+  submitting.value = true;
+  try {
+    const res = await Api.application.planSheep.submit({ ...form });
+    const code = res?.data?.code ?? res?.status;
+    const success = res?.data?.success ?? code === 200;
+    const message = res?.data?.msg || (success ? '保存成功' : '保存失败');
+
+    showToast(message);
+
+    if (success) {
+      setTimeout(() => {
+        router.back();
+      }, 600);
+    }
+  } catch (error) {
+    console.error(error);
+    showToast('系统异常');
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.site-planning-create {
+  background: linear-gradient(180deg, #f7e9df 0%, rgba(255, 255, 255, 0) 12%) !important;
+  min-height: 100vh;
+  padding-bottom: 200rpx;
+  box-sizing: border-box;
+
+  .title {
+    font-weight: 600;
+    font-size: 30rpx;
+    line-height: 30rpx;
+    margin-bottom: 32rpx;
+  }
+
+  .mtop20 {
+    margin-top: 20rpx;
+  }
+
+  .base-wrapper {
+    padding: 0 26rpx;
+    box-sizing: border-box;
+
+    .baseinfo {
+      padding: 32rpx 24rpx 48rpx;
+      box-sizing: border-box;
+      border-radius: 20rpx;
+      background-color: #fff;
+      position: relative;
+
+      .save-btn {
+        margin-top: 32rpx;
+        border-radius: 8rpx;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- replace the placeholder site planning entry with a Vant-based create form
- route the site planning app entry to the new Create view component

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fc6fa6a82c83278e31b675d3f46722