### PR TITLE
Enhance WorkTime internationalization

### DIFF
--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1,5 +1,9 @@
 export default {
   common: {
+    cancel: 'Cancel',
+    confirm: 'Confirm',
+    expand: 'Expand',
+    collapse: 'Collapse',
     errors: {
       system: 'A system error occurred',
       tokenExpired: 'Your session has expired. Please sign in again.',
@@ -261,6 +265,10 @@ export default {
       dateLabel: 'Attendance date',
       punchDetailTitle: 'Punch details',
       punchTimeLabel: 'Punch time',
+      weekNames: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+      monthLabel: 'Month {month}',
+      yearLabel: 'Year {year}',
+      yearOption: 'Year {year}',
       groups: {
         attendance: 'Attendance data',
         overtime: 'Overtime data',

--- a/src/locales/vi-VN.js
+++ b/src/locales/vi-VN.js
@@ -1,5 +1,9 @@
 export default {
   common: {
+    cancel: 'Hủy',
+    confirm: 'Xác nhận',
+    expand: 'Mở rộng',
+    collapse: 'Thu gọn',
     errors: {
       system: 'Đã xảy ra lỗi hệ thống',
       tokenExpired: 'Phiên đăng nhập đã hết hạn, vui lòng đăng nhập lại',
@@ -261,6 +265,10 @@ export default {
       dateLabel: 'Ngày tra cứu',
       punchDetailTitle: 'Chi tiết chấm công',
       punchTimeLabel: 'Thời gian chấm công',
+      weekNames: ['T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'CN'],
+      monthLabel: 'Tháng {month}',
+      yearLabel: 'Năm {year}',
+      yearOption: 'Năm {year}',
       groups: {
         attendance: 'Dữ liệu chấm công',
         overtime: 'Dữ liệu tăng ca',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1,5 +1,9 @@
 export default {
   common: {
+    cancel: '取消',
+    confirm: '确定',
+    expand: '展开',
+    collapse: '收起',
     errors: {
       system: '系统错误',
       tokenExpired: '用户令牌过期，请重新登录',
@@ -261,6 +265,10 @@ export default {
       dateLabel: '查询日期',
       punchDetailTitle: '打卡明细',
       punchTimeLabel: '打卡时间',
+      weekNames: ['一', '二', '三', '四', '五', '六', '日'],
+      monthLabel: '{month}月',
+      yearLabel: '{year}年',
+      yearOption: '{year}年',
       groups: {
         attendance: '出勤数据',
         overtime: '加班数据',

--- a/src/views/account/me/WorkTime.vue
+++ b/src/views/account/me/WorkTime.vue
@@ -22,7 +22,7 @@
 
       <!-- 打卡明细 -->
       <section class="card sign-detail">
-        <div class="card__title">{{ t('me.workTime.punchDetailTitle') }}</div>
+        <div class="card__title card__title--section">{{ t('me.workTime.punchDetailTitle') }}</div>
         <div class="card__content">
           <div class="field">
             <div class="field__label">{{ t('me.workTime.punchTimeLabel') }}</div>
@@ -34,7 +34,7 @@
       <!-- 分组数据 -->
       <section v-for="group in groups" :key="group.key" class="card card--collapsible" :class="{ 'is-collapsed': !isGroupExpanded(group.key) }">
         <button
-          class="card__title card__title--toggle"
+          class="card__title card__title--toggle card__title--section"
           type="button"
           :aria-expanded="isGroupExpanded(group.key)"
           @click="toggleGroup(group.key)"
@@ -229,7 +229,7 @@ watch(
     padding: 0 16px 24px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    row-gap: 12px;
   }
 
   &__loading {
@@ -245,8 +245,8 @@ watch(
 
 .card {
   background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 6px 24px rgba(35, 44, 80, 0.08);
+  border-radius: 0;
+  box-shadow: none;
   overflow: hidden;
 
   &__title {
@@ -286,10 +286,12 @@ watch(
     }
   }
 
-  &.is-collapsed {
-    border-bottom-left-radius: 12px;
-    border-bottom-right-radius: 12px;
-  }
+}
+
+.card__title--section {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
 }
 
 

--- a/src/views/account/me/WorkTime.vue
+++ b/src/views/account/me/WorkTime.vue
@@ -10,8 +10,6 @@
       placeholder
       @click-left="handleBack"
     />
-    <div class="me-work-time__top-bg"></div>
-
     <main class="me-work-time__body">
       <!-- 日期卡片：月视图 / 周视图（收起） -->
       <section class="card card--date">
@@ -399,7 +397,7 @@ onMounted(() => {
 <style scoped lang="scss">
 .me-work-time {
   min-height: 100vh;
-  background: linear-gradient(180deg, #3060ed 0%, rgba(48, 96, 237, 0) 200px), #f7f8fa;
+  background: #f7f8fa;
   padding: 0 0 24px;
   padding-bottom: calc(96px + constant(safe-area-inset-bottom));
   padding-bottom: calc(96px + env(safe-area-inset-bottom));
@@ -408,13 +406,9 @@ onMounted(() => {
   &__nav {
     background: transparent;
   }
-  &__top-bg {
-    height: 160px;
-    background: #3060ed;
-  }
 
   &__body {
-    margin-top: -120px;
+    margin-top: 16px;
     padding: 0 16px 24px;
     display: flex;
     flex-direction: column;

--- a/src/views/account/me/WorkTime.vue
+++ b/src/views/account/me/WorkTime.vue
@@ -77,16 +77,26 @@
       </section>
 
       <!-- 分组数据 -->
-      <section v-for="group in groups" :key="group.key" class="card">
-        <div class="card__title">{{ group.label }}</div>
-        <div class="card__content card__content--grid">
-          <div v-for="col in group.columns" :key="col.prop" class="field">
-            <div class="field__label">{{ col.label }}</div>
-            <div class="field__value" :class="{ 'field__value--zero': isZeroValue(col.prop) }">
-              {{ formatValue(col.prop) }}
+      <section v-for="group in groups" :key="group.key" class="card card--collapsible" :class="{ 'is-collapsed': !isGroupExpanded(group.key) }">
+        <button
+          class="card__title card__title--toggle"
+          type="button"
+          :aria-expanded="isGroupExpanded(group.key)"
+          @click="toggleGroup(group.key)"
+        >
+          <span>{{ group.label }}</span>
+          <van-icon :name="isGroupExpanded(group.key) ? 'arrow-up' : 'arrow-down'" />
+        </button>
+        <transition name="collapse">
+          <div v-show="isGroupExpanded(group.key)" class="card__content card__content--grid">
+            <div v-for="col in group.columns" :key="col.prop" class="field">
+              <div class="field__label">{{ col.label }}</div>
+              <div class="field__value" :class="{ 'field__value--zero': isZeroValue(col.prop) }">
+                {{ formatValue(col.prop) }}
+              </div>
             </div>
           </div>
-        </div>
+        </transition>
       </section>
     </main>
 
@@ -243,6 +253,25 @@ const groups = computed(() => [
 ]);
 
 const punchTime = computed(() => pageInfo.value?.punchCardData || t('me.workTime.emptyValue'));
+
+const expandedGroups = ref({
+  attendance: true,
+  overtime: true,
+  abnormal: true,
+  correction: true,
+});
+
+function isGroupExpanded(key) {
+  const state = expandedGroups.value?.[key];
+  return state !== false;
+}
+
+function toggleGroup(key) {
+  expandedGroups.value = {
+    ...expandedGroups.value,
+    [key]: !isGroupExpanded(key),
+  };
+}
 
 /** ===== 日历计算（周起始：周一） ===== */
 function buildMonthWeeks(baseMonth /* dayjs startOf('month') */) {
@@ -448,6 +477,33 @@ onMounted(() => {
   }
 }
 
+.card--collapsible {
+  .card__title--toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px;
+    background: transparent;
+    border: 0;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+
+    .van-icon {
+      color: #848488;
+      font-size: 18px;
+    }
+  }
+
+  &.is-collapsed {
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+  }
+}
+
 /* ===== 日历样式 ===== */
 .dc-cal__header {
   display: flex;
@@ -601,5 +657,15 @@ onMounted(() => {
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
+}
+
+.collapse-enter-active,
+.collapse-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+.collapse-enter-from,
+.collapse-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
 }
 </style>

--- a/src/views/account/me/WorkTime.vue
+++ b/src/views/account/me/WorkTime.vue
@@ -16,52 +16,7 @@
         <div class="card__title">{{ t('me.workTime.dateLabel') }}</div>
 
         <div class="card__content">
-          <!-- 日历头部 -->
-          <div class="dc-cal__header">
-            <van-icon name="arrow-left" class="dc-cal__arrow" @click="goPrevMonth" />
-            <div class="dc-cal__title">
-              <span class="dc-cal__month">{{ currentMonthLabel }}</span>
-              <button class="dc-cal__year" type="button" @click="showYearPicker = true">
-                {{ currentYearLabel }}
-                <van-icon name="arrow-down" />
-              </button>
-            </div>
-            <van-icon name="arrow" class="dc-cal__arrow" @click="goNextMonth" />
-          </div>
-
-          <!-- 星期标题 -->
-          <div class="dc-cal__week">
-            <div v-for="w in weekNames" :key="w" class="dc-cal__week-item">{{ w }}</div>
-          </div>
-
-          <!-- 日期网格：展开=整月；收起=仅选中的那一行 -->
-          <div class="dc-cal__grid" :class="{ 'is-collapsed': isCollapsed }">
-            <div v-for="(week, wIdx) in displayWeeks" :key="wIdx" class="dc-cal__row">
-              <div
-                v-for="cell in week"
-                :key="cell.date"
-                class="dc-cal__cell"
-                :class="{
-                  'is-out': !cell.inMonth,
-                  'is-today': cell.date === today,
-                  'is-selected': cell.date === selectedDate,
-                }"
-                @click="onCellClick(cell)"
-              >
-                <div v-if="cell.date === today" class="dc-cal__dot"></div>
-                <span class="dc-cal__text">{{ cell.day }}</span>
-              </div>
-            </div>
-
-            <!-- 收起态的小滑块装饰（示意） -->
-            <div v-if="isCollapsed" class="dc-cal__bar"></div>
-          </div>
-
-          <!-- 展开/收起开关 -->
-          <div class="dc-cal__toggle" @click="isCollapsed = !isCollapsed">
-            <span>{{ isCollapsed ? t('common.expand') : t('common.collapse') }}</span>
-            <van-icon :name="isCollapsed ? 'arrow-down' : 'arrow-up'" />
-          </div>
+          <work-time-calendar v-model="selectedDate" />
         </div>
       </section>
 
@@ -106,89 +61,31 @@
       </div>
     </transition>
 
-    <!-- 年份选择器 -->
-    <van-popup v-model:show="showYearPicker" round position="bottom" :safe-area-inset-bottom="true">
-      <van-picker
-        :columns="yearColumns"
-        :default-index="yearDefaultIndex"
-        :visible-option-num="5"
-        :cancel-button-text="t('common.cancel')"
-        :confirm-button-text="t('common.confirm')"
-        @confirm="onYearConfirm"
-        @cancel="showYearPicker = false"
-      />
-    </van-popup>
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import dayjs from 'dayjs';
 import Api from '@/api/index';
 import { showToast } from 'vant';
+import WorkTimeCalendar from './components/WorkTimeCalendar.vue';
 
 const router = useRouter();
-const { t, tm } = useI18n();
+const { t } = useI18n();
 
 const today = dayjs().format('YYYY-MM-DD');
-const selectedDate = ref(today); // 当前选中日期（字符串）
-const visibleMonth = ref(dayjs(today).startOf('month')); // 当前视图所在月份
-const isCollapsed = ref(false); // 默认先展示整月，可点击收起
-const showYearPicker = ref(false);
-
+const selectedDate = ref(today);
 const pageInfo = ref({});
 const loading = ref(false);
 
-const defaultWeekNames = ['一', '二', '三', '四', '五', '六', '日'];
-
-const weekNames = computed(() => {
-  const names = typeof tm === 'function' ? tm('me.workTime.weekNames') : null;
-  if (Array.isArray(names) && names.length === 7) {
-    return names;
-  }
-  return defaultWeekNames;
-});
-
-function getTranslationWithFallback(key, params, fallback) {
-  const translated = t(key, params);
-  if (translated && translated !== key) {
-    return translated;
-  }
-  return fallback;
-}
-
-function formatMonthLabel(monthValue) {
-  return getTranslationWithFallback('me.workTime.monthLabel', { month: monthValue }, `${monthValue}月`);
-}
-
-function formatYearLabel(yearValue) {
-  return getTranslationWithFallback('me.workTime.yearLabel', { year: yearValue }, `${yearValue}年`);
-}
-
-function formatYearOption(yearValue) {
-  const fallback = formatYearLabel(yearValue);
-  return getTranslationWithFallback('me.workTime.yearOption', { year: yearValue }, fallback);
-}
-
-const currentMonthLabel = computed(() => formatMonthLabel(visibleMonth.value.format('M')));
-
-const currentYearLabel = computed(() => formatYearLabel(visibleMonth.value.format('YYYY')));
-
-// 年份列（以当前年为中心，向前后各 10 年）
-const yearColumns = computed(() => {
-  const current = dayjs().year();
-  const list = [];
-  for (let y = current - 10; y <= current + 10; y++) {
-    list.push({ text: formatYearOption(y), value: y });
-  }
-  return list;
-});
-const yearDefaultIndex = computed(() => {
-  const y = visibleMonth.value.year();
-  const idx = yearColumns.value.findIndex((i) => i.value === y);
-  return idx >= 0 ? idx : 10;
+const expandedGroups = ref({
+  attendance: true,
+  overtime: true,
+  abnormal: true,
+  correction: true,
 });
 
 const groups = computed(() => [
@@ -254,13 +151,6 @@ const groups = computed(() => [
 
 const punchTime = computed(() => pageInfo.value?.punchCardData || t('me.workTime.emptyValue'));
 
-const expandedGroups = ref({
-  attendance: true,
-  overtime: true,
-  abnormal: true,
-  correction: true,
-});
-
 function isGroupExpanded(key) {
   const state = expandedGroups.value?.[key];
   return state !== false;
@@ -273,117 +163,10 @@ function toggleGroup(key) {
   };
 }
 
-/** ===== 日历计算（周起始：周一） ===== */
-function buildMonthWeeks(baseMonth /* dayjs startOf('month') */) {
-  const first = baseMonth.startOf('month');
-  const last = baseMonth.endOf('month');
-  const monthStr = first.format('YYYY-MM');
-
-  // day()：0=周日...6=周六；转为周一为一周起点的偏移
-  const mondayOffset = (first.day() + 6) % 7; // 周一=0，周日=6
-  const daysInMonth = last.date();
-
-  const cells = [];
-  // 前导占位
-  for (let i = 0; i < mondayOffset; i++) {
-    const d = first.subtract(mondayOffset - i, 'day');
-    cells.push({
-      date: d.format('YYYY-MM-DD'),
-      day: d.date(),
-      inMonth: false,
-    });
-  }
-  // 当月
-  for (let i = 1; i <= daysInMonth; i++) {
-    const d = dayjs(`${monthStr}-${String(i).padStart(2, '0')}`);
-    cells.push({
-      date: d.format('YYYY-MM-DD'),
-      day: i,
-      inMonth: true,
-    });
-  }
-  // 补齐到 7 的倍数
-  const remain = (7 - (cells.length % 7)) % 7;
-  for (let i = 1; i <= remain; i++) {
-    const d = last.add(i, 'day');
-    cells.push({
-      date: d.format('YYYY-MM-DD'),
-      day: d.date(),
-      inMonth: false,
-    });
-  }
-
-  // 分周
-  const weeks = [];
-  for (let i = 0; i < cells.length; i += 7) {
-    weeks.push(cells.slice(i, i + 7));
-  }
-  return weeks;
-}
-
-const allWeeks = computed(() => buildMonthWeeks(visibleMonth.value));
-
-const activeWeekIndex = computed(() => {
-  const idx = allWeeks.value.flat().findIndex((c) => c.date === selectedDate.value);
-  return idx >= 0 ? Math.floor(idx / 7) : 0;
-});
-
-const displayWeeks = computed(() => {
-  return isCollapsed.value
-    ? [allWeeks.value[activeWeekIndex.value] || allWeeks.value[0]]
-    : allWeeks.value;
-});
-
-/** ===== 交互 ===== */
-function onCellClick(cell) {
-  // 允许点击「非本月」单元直接跳转月份
-  if (!cell.inMonth) {
-    visibleMonth.value = dayjs(cell.date).startOf('month');
-  }
-  selectedDate.value = cell.date;
-  fetchDetail();
-  // 收起状态下，切换行
-  if (isCollapsed.value) {
-    // activeWeekIndex 是计算属性，selectedDate 变化后会自动更新
-  }
-}
-function goPrevMonth() {
-  visibleMonth.value = visibleMonth.value.subtract(1, 'month');
-}
-function goNextMonth() {
-  visibleMonth.value = visibleMonth.value.add(1, 'month');
-}
-function onYearConfirm({ selectedOptions }) {
-  const y = selectedOptions?.[0]?.value;
-  if (typeof y === 'number') {
-    const newMonth = visibleMonth.value.year(y);
-    // 修正日期越界（如 31 号 -> 小月）
-    const d = dayjs(selectedDate.value);
-    if (d.year() !== y) {
-      const safeDay = Math.min(d.date(), newMonth.endOf('month').date());
-      const nextSelected = newMonth.date(safeDay).format('YYYY-MM-DD');
-      selectedDate.value = nextSelected;
-      fetchDetail();
-    }
-    visibleMonth.value = newMonth.startOf('month');
-  }
-  showYearPicker.value = false;
-}
-
-// 如果切换月份后，选中日期不在该月，默认把选中移动到该月的「同日或末日」
-watch(visibleMonth, (m) => {
-  const d = dayjs(selectedDate.value);
-  if (!d.isSame(m, 'month')) {
-    const safeDay = Math.min(d.date(), m.endOf('month').date());
-    selectedDate.value = m.date(safeDay).format('YYYY-MM-DD');
-    fetchDetail();
-  }
-});
-
-/** ===== 原有数据逻辑 ===== */
 function handleBack() {
   router.back();
 }
+
 function formatValue(prop) {
   const raw = pageInfo.value?.[prop];
   if (raw === undefined || raw === null || raw === '') return '0';
@@ -392,6 +175,7 @@ function formatValue(prop) {
   if (!Number.isNaN(num)) return num.toLocaleString();
   return raw;
 }
+
 function isZeroValue(prop) {
   const raw = pageInfo.value?.[prop];
   if (raw === undefined || raw === null || raw === '' || raw === '0') return true;
@@ -418,9 +202,13 @@ async function fetchDetail() {
   }
 }
 
-onMounted(() => {
-  fetchDetail();
-});
+watch(
+  selectedDate,
+  () => {
+    fetchDetail();
+  },
+  { immediate: true },
+);
 </script>
 
 <style scoped lang="scss">
@@ -504,128 +292,6 @@ onMounted(() => {
   }
 }
 
-/* ===== 日历样式 ===== */
-.dc-cal__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 36px;
-  margin-bottom: 8px;
-  user-select: none;
-}
-.dc-cal__arrow {
-  font-size: 18px;
-  color: #333;
-  padding: 6px;
-  border-radius: 8px;
-  &:active {
-    background: #f2f3f5;
-  }
-}
-.dc-cal__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600;
-}
-.dc-cal__month {
-  font-size: 18px;
-  color: #333;
-}
-.dc-cal__year {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  border: 0;
-  background: transparent;
-  font-size: 14px;
-  color: #848488;
-}
-
-.dc-cal__week {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  padding: 6px 0;
-  color: #848488;
-  font-size: 12px;
-}
-.dc-cal__week-item {
-  text-align: center;
-}
-
-.dc-cal__grid {
-  position: relative;
-  display: grid;
-  grid-auto-rows: 44px; /* 每一行高度 */
-  gap: 6px;
-  margin-top: 4px;
-
-  &.is-collapsed {
-    grid-auto-rows: 44px;
-  }
-}
-.dc-cal__row {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 6px;
-}
-.dc-cal__cell {
-  position: relative;
-  height: 44px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333;
-  font-size: 15px;
-  background: #fff;
-
-  &.is-out {
-    color: #c5c8ce;
-  }
-  &.is-today .dc-cal__text {
-    font-weight: 700;
-  }
-  &.is-selected {
-    background: rgba(48, 96, 237, 0.08);
-    box-shadow: inset 0 0 0 2px #3060ed;
-    color: #3060ed;
-    .dc-cal__text {
-      font-weight: 700;
-    }
-  }
-}
-.dc-cal__dot {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #3060ed;
-}
-.dc-cal__text {
-  line-height: 1;
-}
-
-.dc-cal__bar {
-  width: 54px;
-  height: 4px;
-  background: #333;
-  border-radius: 999px;
-  opacity: 0.3;
-  margin: 6px auto 0;
-}
-
-.dc-cal__toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 0 2px;
-  color: #848488;
-  font-size: 13px;
-}
 
 /* 其它字段 */
 .field {

--- a/src/views/account/me/components/WorkTimeCalendar.vue
+++ b/src/views/account/me/components/WorkTimeCalendar.vue
@@ -126,19 +126,21 @@ function formatYearOption(yearValue) {
 const currentMonthLabel = computed(() => formatMonthLabel(visibleMonth.value.format('M')));
 const currentYearLabel = computed(() => formatYearLabel(visibleMonth.value.format('YYYY')));
 
+const currentYear = computed(() => dayjs().year());
+
 const yearColumns = computed(() => {
-  const current = dayjs().year();
   const list = [];
-  for (let y = current - 10; y <= current + 10; y++) {
+  const maxYear = currentYear.value;
+  const minYear = maxYear - 10;
+  for (let y = minYear; y <= maxYear; y++) {
     list.push({ text: formatYearOption(y), value: y });
   }
   return list;
 });
 
 const yearDefaultIndex = computed(() => {
-  const y = visibleMonth.value.year();
-  const idx = yearColumns.value.findIndex((i) => i.value === y);
-  return idx >= 0 ? idx : 10;
+  const idx = yearColumns.value.findIndex((i) => i.value === currentYear.value);
+  return idx >= 0 ? idx : yearColumns.value.length - 1;
 });
 
 function buildMonthWeeks(baseMonth) {

--- a/src/views/account/me/components/WorkTimeCalendar.vue
+++ b/src/views/account/me/components/WorkTimeCalendar.vue
@@ -33,14 +33,17 @@
           <span class="dc-cal__text">{{ cell.day }}</span>
         </div>
       </div>
-
-      <div v-if="isCollapsed" class="dc-cal__bar"></div>
     </div>
 
-    <div class="dc-cal__toggle" @click="isCollapsed = !isCollapsed">
-      <span>{{ isCollapsed ? t('common.expand') : t('common.collapse') }}</span>
-      <van-icon :name="isCollapsed ? 'arrow-down' : 'arrow-up'" />
-    </div>
+    <button
+      class="dc-cal__bar"
+      type="button"
+      :aria-expanded="!isCollapsed"
+      @click="toggleCollapse"
+    >
+      <span class="dc-cal__bar-handle"></span>
+      <van-icon class="dc-cal__bar-icon" :name="isCollapsed ? 'arrow-down' : 'arrow-up'" />
+    </button>
 
     <van-popup v-model:show="showYearPicker" round position="bottom" :safe-area-inset-bottom="true">
       <van-picker
@@ -222,6 +225,10 @@ function goNextMonth() {
   visibleMonth.value = visibleMonth.value.add(1, 'month');
 }
 
+function toggleCollapse() {
+  isCollapsed.value = !isCollapsed.value;
+}
+
 function onYearConfirm({ selectedOptions }) {
   const y = selectedOptions?.[0]?.value;
   if (typeof y === 'number') {
@@ -375,21 +382,32 @@ watch(visibleMonth, (m) => {
 }
 
 .dc-cal__bar {
+  margin: 6px auto 0;
+  padding: 6px 0 2px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: #848488;
+  font-size: 13px;
+}
+
+.dc-cal__bar:active {
+  opacity: 0.8;
+}
+
+.dc-cal__bar-handle {
   width: 54px;
   height: 4px;
   background: #333;
   border-radius: 999px;
   opacity: 0.3;
-  margin: 6px auto 0;
 }
 
-.dc-cal__toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 0 2px;
-  color: #848488;
-  font-size: 13px;
+.dc-cal__bar-icon {
+  font-size: 14px;
 }
 </style>

--- a/src/views/account/me/components/WorkTimeCalendar.vue
+++ b/src/views/account/me/components/WorkTimeCalendar.vue
@@ -1,0 +1,393 @@
+<template>
+  <div class="work-time-calendar">
+    <div class="dc-cal__header">
+      <van-icon name="arrow-left" class="dc-cal__arrow" @click="goPrevMonth" />
+      <div class="dc-cal__title">
+        <span class="dc-cal__month">{{ currentMonthLabel }}</span>
+        <button class="dc-cal__year" type="button" @click="showYearPicker = true">
+          {{ currentYearLabel }}
+          <van-icon name="arrow-down" />
+        </button>
+      </div>
+      <van-icon name="arrow" class="dc-cal__arrow" @click="goNextMonth" />
+    </div>
+
+    <div class="dc-cal__week">
+      <div v-for="w in weekNames" :key="w" class="dc-cal__week-item">{{ w }}</div>
+    </div>
+
+    <div class="dc-cal__grid" :class="{ 'is-collapsed': isCollapsed }">
+      <div v-for="(week, wIdx) in displayWeeks" :key="wIdx" class="dc-cal__row">
+        <div
+          v-for="cell in week"
+          :key="cell.date"
+          class="dc-cal__cell"
+          :class="{
+            'is-out': !cell.inMonth,
+            'is-today': cell.date === today,
+            'is-selected': cell.date === internalSelectedDate,
+          }"
+          @click="onCellClick(cell)"
+        >
+          <div v-if="cell.date === today" class="dc-cal__dot"></div>
+          <span class="dc-cal__text">{{ cell.day }}</span>
+        </div>
+      </div>
+
+      <div v-if="isCollapsed" class="dc-cal__bar"></div>
+    </div>
+
+    <div class="dc-cal__toggle" @click="isCollapsed = !isCollapsed">
+      <span>{{ isCollapsed ? t('common.expand') : t('common.collapse') }}</span>
+      <van-icon :name="isCollapsed ? 'arrow-down' : 'arrow-up'" />
+    </div>
+
+    <van-popup v-model:show="showYearPicker" round position="bottom" :safe-area-inset-bottom="true">
+      <van-picker
+        :columns="yearColumns"
+        :default-index="yearDefaultIndex"
+        :visible-option-num="5"
+        :cancel-button-text="t('common.cancel')"
+        :confirm-button-text="t('common.confirm')"
+        @confirm="onYearConfirm"
+        @cancel="showYearPicker = false"
+      />
+    </van-popup>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import dayjs from 'dayjs';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: () => dayjs().format('YYYY-MM-DD'),
+  },
+  defaultCollapsed: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'date-change']);
+
+const { t, tm } = useI18n();
+
+const today = dayjs().format('YYYY-MM-DD');
+const internalSelectedDate = ref(props.modelValue || today);
+const visibleMonth = ref(dayjs(internalSelectedDate.value).startOf('month'));
+const isCollapsed = ref(props.defaultCollapsed);
+const showYearPicker = ref(false);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (val && val !== internalSelectedDate.value) {
+      internalSelectedDate.value = val;
+      visibleMonth.value = dayjs(val).startOf('month');
+    }
+  },
+);
+
+const defaultWeekNames = ['一', '二', '三', '四', '五', '六', '日'];
+
+const weekNames = computed(() => {
+  const names = typeof tm === 'function' ? tm('me.workTime.weekNames') : null;
+  if (Array.isArray(names) && names.length === 7) {
+    return names;
+  }
+  return defaultWeekNames;
+});
+
+function getTranslationWithFallback(key, params, fallback) {
+  const translated = t(key, params);
+  if (translated && translated !== key) {
+    return translated;
+  }
+  return fallback;
+}
+
+function formatMonthLabel(monthValue) {
+  return getTranslationWithFallback('me.workTime.monthLabel', { month: monthValue }, `${monthValue}月`);
+}
+
+function formatYearLabel(yearValue) {
+  return getTranslationWithFallback('me.workTime.yearLabel', { year: yearValue }, `${yearValue}年`);
+}
+
+function formatYearOption(yearValue) {
+  const fallback = formatYearLabel(yearValue);
+  return getTranslationWithFallback('me.workTime.yearOption', { year: yearValue }, fallback);
+}
+
+const currentMonthLabel = computed(() => formatMonthLabel(visibleMonth.value.format('M')));
+const currentYearLabel = computed(() => formatYearLabel(visibleMonth.value.format('YYYY')));
+
+const yearColumns = computed(() => {
+  const current = dayjs().year();
+  const list = [];
+  for (let y = current - 10; y <= current + 10; y++) {
+    list.push({ text: formatYearOption(y), value: y });
+  }
+  return list;
+});
+
+const yearDefaultIndex = computed(() => {
+  const y = visibleMonth.value.year();
+  const idx = yearColumns.value.findIndex((i) => i.value === y);
+  return idx >= 0 ? idx : 10;
+});
+
+function buildMonthWeeks(baseMonth) {
+  const first = baseMonth.startOf('month');
+  const last = baseMonth.endOf('month');
+  const monthStr = first.format('YYYY-MM');
+
+  const mondayOffset = (first.day() + 6) % 7;
+  const daysInMonth = last.date();
+
+  const cells = [];
+  for (let i = 0; i < mondayOffset; i++) {
+    const d = first.subtract(mondayOffset - i, 'day');
+    cells.push({
+      date: d.format('YYYY-MM-DD'),
+      day: d.date(),
+      inMonth: false,
+    });
+  }
+  for (let i = 1; i <= daysInMonth; i++) {
+    const d = dayjs(`${monthStr}-${String(i).padStart(2, '0')}`);
+    cells.push({
+      date: d.format('YYYY-MM-DD'),
+      day: i,
+      inMonth: true,
+    });
+  }
+  const remain = (7 - (cells.length % 7)) % 7;
+  for (let i = 1; i <= remain; i++) {
+    const d = last.add(i, 'day');
+    cells.push({
+      date: d.format('YYYY-MM-DD'),
+      day: d.date(),
+      inMonth: false,
+    });
+  }
+
+  const weeks = [];
+  for (let i = 0; i < cells.length; i += 7) {
+    weeks.push(cells.slice(i, i + 7));
+  }
+  return weeks;
+}
+
+const allWeeks = computed(() => buildMonthWeeks(visibleMonth.value));
+
+const activeWeekIndex = computed(() => {
+  const idx = allWeeks.value.flat().findIndex((c) => c.date === internalSelectedDate.value);
+  return idx >= 0 ? Math.floor(idx / 7) : 0;
+});
+
+const displayWeeks = computed(() => (isCollapsed.value ? [allWeeks.value[activeWeekIndex.value] || allWeeks.value[0]] : allWeeks.value));
+
+function emitSelectedDate(nextDate) {
+  const formatted = dayjs(nextDate).format('YYYY-MM-DD');
+  if (formatted === internalSelectedDate.value) {
+    return formatted;
+  }
+  internalSelectedDate.value = formatted;
+  emit('update:modelValue', formatted);
+  emit('date-change', formatted);
+  return formatted;
+}
+
+function onCellClick(cell) {
+  if (!cell.inMonth) {
+    const nextDate = emitSelectedDate(cell.date);
+    visibleMonth.value = dayjs(nextDate).startOf('month');
+  } else {
+    emitSelectedDate(cell.date);
+  }
+}
+
+function goPrevMonth() {
+  visibleMonth.value = visibleMonth.value.subtract(1, 'month');
+}
+
+function goNextMonth() {
+  visibleMonth.value = visibleMonth.value.add(1, 'month');
+}
+
+function onYearConfirm({ selectedOptions }) {
+  const y = selectedOptions?.[0]?.value;
+  if (typeof y === 'number') {
+    const newMonth = visibleMonth.value.year(y);
+    const current = dayjs(internalSelectedDate.value);
+    if (!current.isSame(newMonth, 'year')) {
+      const safeDay = Math.min(current.date(), newMonth.endOf('month').date());
+      const nextSelected = newMonth.date(safeDay).format('YYYY-MM-DD');
+      emitSelectedDate(nextSelected);
+    }
+    visibleMonth.value = newMonth.startOf('month');
+  }
+  showYearPicker.value = false;
+}
+
+watch(visibleMonth, (m) => {
+  const current = dayjs(internalSelectedDate.value);
+  if (!current.isSame(m, 'month')) {
+    const safeDay = Math.min(current.date(), m.endOf('month').date());
+    const nextSelected = m.date(safeDay).format('YYYY-MM-DD');
+    emitSelectedDate(nextSelected);
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.work-time-calendar {
+  display: flex;
+  flex-direction: column;
+}
+
+.dc-cal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 36px;
+  margin-bottom: 8px;
+  user-select: none;
+}
+
+.dc-cal__arrow {
+  font-size: 18px;
+  color: #333;
+  padding: 6px;
+  border-radius: 8px;
+
+  &:active {
+    background: #f2f3f5;
+  }
+}
+
+.dc-cal__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  color: #333;
+  font-weight: 600;
+}
+
+.dc-cal__month {
+  min-width: 56px;
+  text-align: right;
+}
+
+.dc-cal__year {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 0;
+  background: #f2f3f5;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.dc-cal__week {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  padding: 6px 0;
+  color: #848488;
+  font-size: 12px;
+}
+
+.dc-cal__week-item {
+  text-align: center;
+}
+
+.dc-cal__grid {
+  position: relative;
+  display: grid;
+  grid-auto-rows: 44px;
+  gap: 6px;
+  margin-top: 4px;
+
+  &.is-collapsed {
+    grid-auto-rows: 44px;
+  }
+}
+
+.dc-cal__row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+}
+
+.dc-cal__cell {
+  position: relative;
+  height: 44px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #333;
+  font-size: 15px;
+  background: #fff;
+
+  &.is-out {
+    color: #c5c8ce;
+  }
+
+  &.is-today .dc-cal__text {
+    font-weight: 700;
+  }
+
+  &.is-selected {
+    background: rgba(48, 96, 237, 0.08);
+    box-shadow: inset 0 0 0 2px #3060ed;
+    color: #3060ed;
+
+    .dc-cal__text {
+      font-weight: 700;
+    }
+  }
+}
+
+.dc-cal__dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #3060ed;
+}
+
+.dc-cal__text {
+  line-height: 1;
+}
+
+.dc-cal__bar {
+  width: 54px;
+  height: 4px;
+  background: #333;
+  border-radius: 999px;
+  opacity: 0.3;
+  margin: 6px auto 0;
+}
+
+.dc-cal__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 0 2px;
+  color: #848488;
+  font-size: 13px;
+}
+</style>

--- a/src/views/account/me/components/WorkTimeCalendar.vue
+++ b/src/views/account/me/components/WorkTimeCalendar.vue
@@ -135,7 +135,7 @@ const yearColumns = computed(() => {
   const list = [];
   const maxYear = currentYear.value;
   const minYear = maxYear - 10;
-  for (let y = minYear; y <= maxYear; y++) {
+  for (let y = maxYear; y >= minYear; y -= 1) {
     list.push({ text: formatYearOption(y), value: y });
   }
   return list;


### PR DESCRIPTION
## Summary
- localize the WorkTime calendar header, week names, and year picker labels
- add matching zh-CN, en-US, and vi-VN translations for common actions used on the WorkTime page

## Testing
- npm run lint *(fails: existing lint errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_6901af826b688327916f0ee58f029ef7