### PR TITLE
feat: update tabbar icons

### DIFF
--- a/src/layouts/TabLayout.vue
+++ b/src/layouts/TabLayout.vue
@@ -8,8 +8,15 @@
         v-for="r in tabRoutes"
         :key="r.name"
         :to="{ name: r.name }"
-        :icon="r.meta.icon"
+        :icon="isCustomIcon(r.meta.icon) ? undefined : r.meta.icon"
       >
+        <template v-if="isCustomIcon(r.meta.icon)" #icon="{ active }">
+          <img
+            :src="getTabbarIcon(r.meta.icon, active)"
+            class="tabbar-icon"
+            :alt="t(r.meta.title)"
+          />
+        </template>
         {{ t(r.meta.title) }}
       </van-tabbar-item>
     </van-tabbar>
@@ -31,6 +38,9 @@ const tabRoutes = computed(() => router.getRoutes().filter((r) => r.meta?.tabbar
 // 仅当当前路径 === /home 或 /me 或 /apps 时显示 TabBar（严格匹配）
 const ALLOW_PATHS = ['/home', '/me', '/apps', '/'];
 const showTabbar = computed(() => ALLOW_PATHS.some((p) => route.path === p));
+
+const isCustomIcon = (icon) => icon && typeof icon === 'object';
+const getTabbarIcon = (icon, isActive) => (isActive ? icon.active : icon.inactive);
 </script>
 
 <style scoped>
@@ -43,5 +53,9 @@ const showTabbar = computed(() => ALLOW_PATHS.some((p) => route.path === p));
   flex: 1;
   overflow: auto;
   background: #f7f8fa;
+}
+.tabbar-icon {
+  width: 24px;
+  height: 24px;
 }
 </style>

--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -5,7 +5,15 @@ export default {
     {
       path: '',
       name: 'apps',
-      meta: { title: 'routes.apps', icon: 'todo-list-o', tabbar: true, requiresAuth: true },
+      meta: {
+        title: 'routes.apps',
+        icon: {
+          active: '/images/layouts/icon-tabbar-工作台-选中.svg',
+          inactive: '/images/layouts/icon-tabbar-工作台-未选中.svg',
+        },
+        tabbar: true,
+        requiresAuth: true,
+      },
       component: () => import('@/views/apps/index.vue'),
     },
     {

--- a/src/router/modules/home.js
+++ b/src/router/modules/home.js
@@ -1,6 +1,14 @@
 export default {
   path: 'home',
   name: 'home',
-  meta: { title: 'routes.home', icon: 'home-o', tabbar: true, requiresAuth: true },
+  meta: {
+    title: 'routes.home',
+    icon: {
+      active: '/images/layouts/icon-tabbar-首页-选中.svg',
+      inactive: '/images/layouts/icon-tabbar-首页-未选中.svg',
+    },
+    tabbar: true,
+    requiresAuth: true,
+  },
   component: () => import('@/views/home/index.vue'),
 }

--- a/src/router/modules/me.js
+++ b/src/router/modules/me.js
@@ -1,12 +1,28 @@
 export default {
   path: 'me',
   component: () => import('@/views/account/me/Layout.vue'),
-  meta: { title: 'routes.me', icon: 'user-o', tabbar: true, requiresAuth: true },
+  meta: {
+    title: 'routes.me',
+    icon: {
+      active: '/images/layouts/icon-tabbar-我的-选中.svg',
+      inactive: '/images/layouts/icon-tabbar-我的-未选中.svg',
+    },
+    tabbar: true,
+    requiresAuth: true,
+  },
   children: [
     {
       path: '',
       name: 'me',
-      meta: { title: 'routes.me', icon: 'user-o', tabbar: true, requiresAuth: true },
+      meta: {
+        title: 'routes.me',
+        icon: {
+          active: '/images/layouts/icon-tabbar-我的-选中.svg',
+          inactive: '/images/layouts/icon-tabbar-我的-未选中.svg',
+        },
+        tabbar: true,
+        requiresAuth: true,
+      },
       component: () => import('@/views/account/Me.vue'),
     },
     {


### PR DESCRIPTION
## Summary
- switch the tab bar to render custom icon images from the public layouts directory
- configure home, apps, and me routes to reference the new active and inactive tab bar icons

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_69032f06dd808327bca30948ccc9e462