### PR TITLE
feat: add public debug settings page

### DIFF
--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -185,6 +185,7 @@ export default {
       campusApply: 'Campus Application',
       campusApplyDetail: 'Application Details',
     },
+    debugSettings: 'Debug Settings',
   },
   me: {
     navTitle: 'Profile',

--- a/src/locales/vi-VN.js
+++ b/src/locales/vi-VN.js
@@ -185,6 +185,7 @@ export default {
       campusApply: 'Mẫu ứng tuyển sinh viên',
       campusApplyDetail: 'Chi tiết đơn ứng tuyển',
     },
+    debugSettings: 'Cài đặt gỡ lỗi',
   },
   me: {
     navTitle: 'Cá nhân',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -185,6 +185,7 @@ export default {
       campusApply: '校招投递表单',
       campusApplyDetail: '投递详情',
     },
+    debugSettings: '调试设置',
   },
   me: {
     navTitle: '我的',

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,10 @@ async function bootstrap() {
   app.use(plugins);
   setupRouterGuard(router);
 
+  const { useDebugStore } = await import('@/store/debug');
+  const debugStore = useDebugStore();
+  await debugStore.init();
+
   // 2) 全局注册（组件/指令/插件）
   registerComponents(app);
   setupDirectives(app);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,10 +5,12 @@ import recruitModule from './modules/recruit';
 import homeModule from './modules/home';
 import appsModule from './modules/apps.js';
 import meModule from './modules/me';
+import settingsModule from './modules/settings';
 
 const routes = [
   loginModule,
   recruitModule,
+  settingsModule,
   {
     path: '/',
     component: () => import('@/layouts/TabLayout.vue'),

--- a/src/router/modules/settings.js
+++ b/src/router/modules/settings.js
@@ -1,0 +1,10 @@
+export default {
+  path: '/settings/debug',
+  name: 'debugSettings',
+  component: () => import('@/views/settings/DebugSettings.vue'),
+  meta: {
+    title: 'routes.debugSettings',
+    titleFallback: '调试设置',
+    requiresAuth: false,
+  },
+};

--- a/src/store/debug.js
+++ b/src/store/debug.js
@@ -1,0 +1,121 @@
+import { defineStore } from 'pinia';
+
+const STORAGE_KEY = 'debug:vconsole-enabled';
+const VCONSOLE_CDN = 'https://unpkg.com/vconsole@3.15.1/dist/vconsole.min.js';
+
+let vconsoleInstance = null;
+let loaderPromise = null;
+
+function readPersistedState() {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch (error) {
+    console.warn('[debug] Failed to read vconsole flag from storage', error);
+    return false;
+  }
+}
+
+function persistState(enabled) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, enabled ? 'true' : 'false');
+  } catch (error) {
+    console.warn('[debug] Failed to persist vconsole flag', error);
+  }
+}
+
+function loadVConsoleConstructor() {
+  if (typeof window === 'undefined') return Promise.reject(new Error('window unavailable'));
+
+  if (window.VConsole) {
+    return Promise.resolve(window.VConsole);
+  }
+
+  if (!loaderPromise) {
+    loaderPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = VCONSOLE_CDN;
+      script.async = true;
+      script.onload = () => {
+        if (window.VConsole) {
+          resolve(window.VConsole);
+        } else {
+          loaderPromise = null;
+          reject(new Error('VConsole loaded without constructor'));
+        }
+      };
+      script.onerror = () => {
+        loaderPromise = null;
+        reject(new Error('Failed to load VConsole script'));
+      };
+      document.head.appendChild(script);
+    });
+  }
+
+  return loaderPromise;
+}
+
+async function ensureVConsole() {
+  if (vconsoleInstance) return vconsoleInstance;
+
+  const VConsoleConstructor = await loadVConsoleConstructor();
+  vconsoleInstance = new VConsoleConstructor();
+  return vconsoleInstance;
+}
+
+function destroyVConsole() {
+  if (vconsoleInstance && typeof vconsoleInstance.destroy === 'function') {
+    vconsoleInstance.destroy();
+  }
+  vconsoleInstance = null;
+}
+
+export const useDebugStore = defineStore('debug', {
+  state: () => ({
+    vconsoleEnabled: readPersistedState(),
+    initialized: false,
+  }),
+  actions: {
+    async init() {
+      if (this.initialized) return;
+      this.initialized = true;
+
+      if (this.vconsoleEnabled) {
+        try {
+          await ensureVConsole();
+        } catch (error) {
+          console.warn('[debug] Failed to initialize VConsole', error);
+          this.vconsoleEnabled = false;
+          persistState(false);
+        }
+      }
+    },
+    async setVConsoleEnabled(enabled) {
+      if (enabled === this.vconsoleEnabled && this.initialized) {
+        return;
+      }
+
+      if (!this.initialized) {
+        this.initialized = true;
+      }
+
+      if (enabled) {
+        try {
+          await ensureVConsole();
+          this.vconsoleEnabled = true;
+          persistState(true);
+        } catch (error) {
+          console.warn('[debug] Failed to enable VConsole', error);
+          this.vconsoleEnabled = false;
+          persistState(false);
+          throw error;
+        }
+      } else {
+        destroyVConsole();
+        this.vconsoleEnabled = false;
+        persistState(false);
+      }
+    },
+  },
+});

--- a/src/views/settings/DebugSettings.vue
+++ b/src/views/settings/DebugSettings.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="debug-settings">
+    <van-nav-bar
+      class="debug-settings__nav"
+      title="调试设置"
+      left-arrow
+      @click-left="handleBack"
+    />
+
+    <section class="debug-settings__content">
+      <van-cell-group inset>
+        <van-cell
+          title="VConsole 调试面板"
+          label="开启后可在页面底部展开调试工具"
+          class="debug-settings__cell"
+        >
+          <template #right-icon>
+            <van-switch
+              :model-value="debugStore.vconsoleEnabled"
+              :loading="loading"
+              size="24px"
+              @update:model-value="onToggle"
+            />
+          </template>
+        </van-cell>
+      </van-cell-group>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { showFailToast, showToast } from 'vant';
+import { useRouter } from 'vue-router';
+import { useDebugStore } from '@/store/debug';
+
+const router = useRouter();
+const debugStore = useDebugStore();
+const loading = ref(false);
+
+const handleBack = () => {
+  if (window.history.length > 1) {
+    router.back();
+    return;
+  }
+  router.replace('/');
+};
+
+const onToggle = async (value) => {
+  if (loading.value) return;
+  loading.value = true;
+  try {
+    await debugStore.setVConsoleEnabled(value);
+    showToast({
+      message: value ? 'VConsole 已开启' : 'VConsole 已关闭',
+      duration: 800,
+    });
+  } catch (error) {
+    console.warn('[debug] toggle failed', error);
+    showFailToast({ message: 'VConsole 加载失败，请稍后重试' });
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  debugStore.init();
+});
+</script>
+
+<style scoped lang="scss">
+.debug-settings {
+  min-height: 100vh;
+  background-color: #f7f8fa;
+
+  &__nav {
+    --van-nav-bar-background: #fff;
+  }
+
+  &__content {
+    padding: 16px 0;
+  }
+
+  &__cell {
+    align-items: center;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add a dedicated debug settings route that can be accessed without login
- provide a Pinia store to persist and toggle the VConsole debugger via CDN loading
- localize the new route title across supported languages

## Testing
- npm run lint *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_690af588aab08327b85ae5ad2656a8d6