### PR TITLE
feat: support columns field names mapping for dict selector

### DIFF
--- a/src/components/dc-ui/components/Uploader/index.vue
+++ b/src/components/dc-ui/components/Uploader/index.vue
@@ -404,7 +404,7 @@ const downloadAt = (index) => {
 
 <style lang="scss" scoped>
 .dc-uploader {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
 }
 .dc-uploader__header {

--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -120,8 +120,8 @@
           </div>
         </div>
       </van-form>
+      <van-number-keyboard safe-area-inset-bottom />
     </div>
-
     <!-- 底部按钮 -->
     <div v-if="formData.id" class="page-body_footer">
       <van-button block type="success" @click="doAction('submit')">
@@ -323,9 +323,10 @@ function resolveDictOptions(item) {
 
 function resolveColumnsFieldNames(item) {
   const props = item?.props || {};
-  const map = props.columnsFieldNames && typeof props.columnsFieldNames === 'object'
-    ? props.columnsFieldNames
-    : null;
+  const map =
+    props.columnsFieldNames && typeof props.columnsFieldNames === 'object'
+      ? props.columnsFieldNames
+      : null;
   if (map) return map;
   if (props.labelKey || props.valueKey) {
     return {
@@ -608,6 +609,7 @@ function handleFormItemChange(col, val) {
   }
 
   .upload-img-box {
+    margin-bottom: 44px;
     width: 100%;
     overflow: hidden;
     display: flex;
@@ -615,6 +617,7 @@ function handleFormItemChange(col, val) {
     align-items: center;
     position: relative;
     padding: 10px 16px;
+    box-sizing: border-box;
 
     .upload-label {
       width: 96px;

--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -110,6 +110,7 @@
 
               <!-- 上传 -->
               <div v-else-if="item.type === 'upload-img'" class="upload-img-box">
+                <div class="upload-label">{{ item.label }}</div>
                 <div class="upload-box">
                   <dc-uploader v-model="formData[item.prop]" v-bind="item.props.column" />
                 </div>
@@ -579,10 +580,21 @@ function handleFormItemChange(col, val) {
     overflow: hidden;
     display: flex;
     flex-flow: row nowrap;
+    align-items: center;
     position: relative;
+    padding: 10px 16px;
+
+    .upload-label {
+      width: 96px;
+      flex: none;
+      color: #646566;
+      font-size: 28rpx;
+      line-height: 1.4;
+    }
 
     .upload-box {
       flex: 1;
+      padding-left: 16px;
     }
 
     :deep(.wf-upload) {

--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -65,9 +65,6 @@
                 :disabled="item.props?.disabled"
                 :clearable="item.props?.clearable"
                 :columns-field-names="resolveColumnsFieldNames(item)"
-                :dict-params="item.props?.dictParams"
-                :value-type="item.props?.valueType || item.props?.returnType"
-                :separator="item.props?.separator"
                 :max-tag-count="item.props?.maxTagCount"
                 @change="(val) => handleFormItemChange(item, val)"
               />


### PR DESCRIPTION
## Summary
- replace the DictSelector label/value props with a `columnsFieldNames` mapping and document the default field keys
- adjust the MaterialMaintenance view to pass the new mapping helper and reuse the updated option resolution utilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c58f3ecec8327933fc4a185eef008