### PR TITLE
fix: improve material info navigation and feedback

### DIFF
--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -149,6 +149,7 @@
 
 <script setup>
 import { ref, reactive, nextTick, getCurrentInstance, unref } from 'vue';
+import { useRouter } from 'vue-router';
 import { closeToast, showToast } from 'vant';
 import Api from '@/api';
 
@@ -156,6 +157,7 @@ defineOptions({ name: 'MaterialInfo' });
 
 /** ======= state ======= */
 const { proxy } = getCurrentInstance();
+const router = useRouter();
 const pageBodyRef = ref(null);
 const stickyTop = ref(0);
 const isSearchSticky = ref(false);
@@ -491,17 +493,28 @@ function doAction(action) {
         })
         .then((res) => {
           closeToast();
-          const { code } = res || {};
+          const { code, msg } = res?.data || {};
           if (code === 200) {
-            showToast({ message: '保存成功' });
+            showToast({ type: 'success', message: '提交成功' });
+          } else {
+            showToast({ message: msg || '提交失败' });
           }
         })
         .catch((error) => {
           closeToast();
-          showToast({ message: error?.msg || '保存失败' });
+          const message = error?.response?.data?.msg || error?.msg || error?.message;
+          showToast({ message: message || '提交失败' });
         });
     });
   }
+}
+
+function handleBack() {
+  if (window?.history?.length > 1) {
+    router.back();
+    return;
+  }
+  router.replace({ name: 'apps' });
 }
 
 // 原有联动逻辑（照搬）


### PR DESCRIPTION
## Summary
- ensure the Material Info back button navigates to the previous page or the apps hub when history is unavailable
- show a clear success toast on submit and surface API errors when the update request fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c66028938832782947c496b1128e8