### PR TITLE
feat: require all onboarding self form fields

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,9 +5,9 @@ VITE_APP_API = '/api'
 
 VITE_BASE = '/'
 
-VITE_APP_BASE_URL = 'https://www.eastwinbip.com/api'
+# VITE_APP_BASE_URL = 'https://www.eastwinbip.com/api'
 
-# VITE_APP_BASE_URL = 'http://192.168.32.15'
+VITE_APP_BASE_URL = 'http://192.168.32.15'
 # 曾
 # VITE_APP_BASE_URL = 'http://192.168.60.106'
 # 王亮

--- a/src/api/modules/recruit/onboarding.js
+++ b/src/api/modules/recruit/onboarding.js
@@ -3,7 +3,7 @@ import request from '@/utils/http';
 export default {
   getLaborRegisterDetail(params) {
     return request({
-      url: '/blade-bip/LaborRegister/detail',
+      url: '/blade-bip/laborRegister/detail',
       method: 'get',
       params,
     });
@@ -11,7 +11,7 @@ export default {
 
   createLaborRegister(data) {
     return request({
-      url: '/blade-bip/LaborRegister/user-create',
+      url: '/blade-bip/laborRegister/user-create',
       method: 'post',
       data,
     });
@@ -19,7 +19,7 @@ export default {
 
   updateLaborRegister(data) {
     return request({
-      url: '/blade-bip/LaborRegister/update',
+      url: '/blade-bip/laborRegister/update',
       method: 'post',
       data,
     });

--- a/src/components/dc-ui/components/Uploader/index.vue
+++ b/src/components/dc-ui/components/Uploader/index.vue
@@ -119,12 +119,18 @@ const joinUrl = (a, b) => {
   if (!B) return A;
   return `${A.replace(/\/+$/, '')}/${B.replace(/^\/+/, '')}`;
 };
+const isHttpUrl = (val) => /^(https?:)?\/\//i.test(String(val || ''));
+
 const composeLink = (obj) => {
   const link = String(obj?.link || '');
   const name = String(obj?.name || '');
   if (link) return link;
-  if (props.previewBaseDomain && name) return joinUrl(props.previewBaseDomain, name);
-  return '';
+  if (!name) return '';
+  if (isHttpUrl(name)) return name;
+  if (props.previewBaseDomain) return joinUrl(props.previewBaseDomain, name);
+  if (name.startsWith('/')) return joinUrl(props.apiPrefix, name);
+  if (props.apiPrefix) return joinUrl(props.apiPrefix, name);
+  return name;
 };
 
 /* ============ 入口保险：深提取 path / attachId，强制字符串化 ============ */

--- a/src/components/dc-ui/components/Uploader/index.vue
+++ b/src/components/dc-ui/components/Uploader/index.vue
@@ -412,6 +412,9 @@ const downloadAt = (index) => {
 .dc-uploader {
   display: inline-flex;
   flex-direction: column;
+  .van-cell-group {
+    margin: 0;
+  }
 }
 .dc-uploader__header {
   display: flex;
@@ -436,14 +439,14 @@ const downloadAt = (index) => {
     padding: 0 !important; /* 无内边距 */
     display: flex;
     align-items: center; /* 垂直居中 */
+    justify-content: space-between;
     min-height: 44px; /* 可选：行高更友好 */
   }
   :deep(.van-cell__title) {
     display: flex;
     align-items: center; /* 文本与右侧图标基线对齐更自然 */
-    gap: 0; /* 不需要额外间距 */
-    flex: 1;
-    min-width: 0; /* 允许文本区域收缩以显示省略号 */
+    width: 120px;
+    overflow: hidden;
   }
   :deep(.van-cell__title span) {
     overflow: hidden;

--- a/src/components/dc-ui/components/Uploader/index.vue
+++ b/src/components/dc-ui/components/Uploader/index.vue
@@ -442,6 +442,13 @@ const downloadAt = (index) => {
     display: flex;
     align-items: center; /* 文本与右侧图标基线对齐更自然 */
     gap: 0; /* 不需要额外间距 */
+    flex: 1;
+    min-width: 0; /* 允许文本区域收缩以显示省略号 */
+  }
+  :deep(.van-cell__title span) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   :deep(.van-cell__value) {
     /* 防止 value 区域撑开布局（有右侧删除图标） */

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -189,12 +189,20 @@ export default {
         validation: {
           avatarId: 'Please upload your ID photo',
           name: 'Please enter your name',
+          age: 'Please enter your age',
           cardNo: 'Please enter your ID number',
           mobile: 'Please enter your contact number',
+          passportNumber: 'Please enter your passport number',
+          nation: 'Please select your ethnicity',
+          address: 'Please enter your native place',
+          education: 'Please select your education level',
+          graduateSchool: 'Please enter your graduated school',
           idCardFront: 'Please upload the front side of the ID card',
           idCardBack: 'Please upload the back side of the ID card',
           company: 'Please select a company',
           position: 'Please select a position',
+          workYear: 'Please select your years of experience',
+          isAccommodation: 'Please select whether accommodation is provided',
         },
         options: {
           education: {

--- a/src/locales/vi-VN.js
+++ b/src/locales/vi-VN.js
@@ -189,12 +189,20 @@ export default {
         validation: {
           avatarId: 'Vui lòng tải lên ảnh CMND',
           name: 'Vui lòng nhập họ và tên',
+          age: 'Vui lòng nhập tuổi',
           cardNo: 'Vui lòng nhập số CMND',
           mobile: 'Vui lòng nhập số điện thoại',
+          passportNumber: 'Vui lòng nhập số hộ chiếu',
+          nation: 'Vui lòng chọn dân tộc',
+          address: 'Vui lòng nhập quê quán',
+          education: 'Vui lòng chọn trình độ học vấn',
+          graduateSchool: 'Vui lòng nhập trường tốt nghiệp',
           idCardFront: 'Vui lòng tải lên mặt trước CMND',
           idCardBack: 'Vui lòng tải lên mặt sau CMND',
           company: 'Vui lòng chọn công ty',
           position: 'Vui lòng chọn chức danh',
+          workYear: 'Vui lòng chọn kinh nghiệm làm việc',
+          isAccommodation: 'Vui lòng chọn tình trạng chỗ ở',
         },
         options: {
           education: {

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -189,12 +189,20 @@ export default {
         validation: {
           avatarId: '请上传证件照',
           name: '请输入姓名',
+          age: '请输入年龄',
           cardNo: '请输入身份证号',
           mobile: '请输入联系电话',
+          passportNumber: '请输入护照号码',
+          nation: '请选择民族',
+          address: '请输入籍贯',
+          education: '请选择文化程度',
+          graduateSchool: '请输入毕业院校',
           idCardFront: '请上传身份证正面',
           idCardBack: '请上传身份证反面',
           company: '请选择外协公司',
           position: '请选择岗位',
+          workYear: '请选择工作年限',
+          isAccommodation: '请选择是否住宿',
         },
         options: {
           education: {

--- a/src/views/recruit/onboarding/SelfForm.vue
+++ b/src/views/recruit/onboarding/SelfForm.vue
@@ -65,6 +65,9 @@
               :label="t('recruit.onboarding.selfForm.fields.age')"
               :placeholder="t('recruit.onboarding.selfForm.placeholders.input')"
               :readonly="isReadonly"
+              :rules="[
+                { required: true, message: t('recruit.onboarding.selfForm.validation.age') },
+              ]"
             />
             <van-field
               v-model="form.cardNo"
@@ -146,6 +149,12 @@
               :label="t('recruit.onboarding.selfForm.fields.passportNumber')"
               :placeholder="t('recruit.onboarding.selfForm.placeholders.input')"
               :readonly="isReadonly"
+              :rules="[
+                {
+                  required: true,
+                  message: t('recruit.onboarding.selfForm.validation.passportNumber'),
+                },
+              ]"
             />
             <van-field
               name="nation"
@@ -154,6 +163,9 @@
               :placeholder="t('recruit.onboarding.selfForm.placeholders.select')"
               is-link
               readonly
+              :rules="[
+                { validator: () => !!form.nation, message: t('recruit.onboarding.selfForm.validation.nation') },
+              ]"
               @click="openPicker('nation')"
             />
             <van-field
@@ -162,6 +174,9 @@
               :label="t('recruit.onboarding.selfForm.fields.address')"
               :placeholder="t('recruit.onboarding.selfForm.placeholders.input')"
               :readonly="isReadonly"
+              :rules="[
+                { required: true, message: t('recruit.onboarding.selfForm.validation.address') },
+              ]"
             />
             <van-field
               name="education"
@@ -170,6 +185,12 @@
               :placeholder="t('recruit.onboarding.selfForm.placeholders.select')"
               is-link
               readonly
+              :rules="[
+                {
+                  validator: () => !!form.education,
+                  message: t('recruit.onboarding.selfForm.validation.education'),
+                },
+              ]"
               @click="openPicker('education')"
             />
             <van-field
@@ -178,6 +199,12 @@
               :label="t('recruit.onboarding.selfForm.fields.graduateSchool')"
               :placeholder="t('recruit.onboarding.selfForm.placeholders.input')"
               :readonly="isReadonly"
+              :rules="[
+                {
+                  required: true,
+                  message: t('recruit.onboarding.selfForm.validation.graduateSchool'),
+                },
+              ]"
             />
           </van-cell-group>
         </section>
@@ -224,6 +251,12 @@
               :placeholder="t('recruit.onboarding.selfForm.placeholders.select')"
               is-link
               readonly
+              :rules="[
+                {
+                  validator: () => !!form.workYear,
+                  message: t('recruit.onboarding.selfForm.validation.workYear'),
+                },
+              ]"
               @click="openPicker('workYear')"
             />
             <van-field
@@ -233,6 +266,12 @@
               :placeholder="t('recruit.onboarding.selfForm.placeholders.select')"
               is-link
               readonly
+              :rules="[
+                {
+                  validator: () => !!form.isAccommodation,
+                  message: t('recruit.onboarding.selfForm.validation.isAccommodation'),
+                },
+              ]"
               @click="openPicker('accommodation')"
             />
           </van-cell-group>

--- a/src/views/recruit/onboarding/SelfForm.vue
+++ b/src/views/recruit/onboarding/SelfForm.vue
@@ -42,7 +42,7 @@
                     :show-type-hint="false"
                     :placeholder="t('recruit.onboarding.selfForm.placeholders.avatarId')"
                     accept="image/*"
-                    @change="onUploaderChange('avatarId')"
+                    @change="onUploaderChange('avatarId', $event)"
                   />
                 </div>
               </template>
@@ -100,7 +100,7 @@
                     :show-type-hint="false"
                     accept="image/*"
                     :placeholder="t('recruit.onboarding.selfForm.placeholders.idCardFront')"
-                    @change="onUploaderChange('idCardFront')"
+                    @change="onUploaderChange('idCardFront', $event)"
                   />
                 </div>
               </template>
@@ -126,7 +126,7 @@
                     :show-type-hint="false"
                     accept="image/*"
                     :placeholder="t('recruit.onboarding.selfForm.placeholders.idCardBack')"
-                    @change="(e) => onUploaderChange('idCardBack', e)"
+                    @change="onUploaderChange('idCardBack', $event)"
                   />
                 </div>
               </template>
@@ -546,7 +546,7 @@ const displayLabel = (value, columns) => {
   return col ? col.text : value;
 };
 
-const onUploaderChange = (key) => (files) => {
+const onUploaderChange = (key, files) => {
   const first = Array.isArray(files) ? files[0] : files;
   const link = first?.link || first?.path || '';
   form[key] = link;

--- a/src/views/recruit/onboarding/SelfForm.vue
+++ b/src/views/recruit/onboarding/SelfForm.vue
@@ -1,11 +1,10 @@
 <template>
   <div class="recruit-onboarding-self">
-    <van-nav-bar
+    <!-- <van-nav-bar
       :title="t('recruit.onboarding.selfForm.title')"
       left-arrow
-      fixed
       @click-left="handleBack"
-    />
+    /> -->
 
     <div class="recruit-onboarding-self__body">
       <van-form ref="formRef" :show-error="false" @submit="handleSubmit">
@@ -164,7 +163,10 @@
               is-link
               readonly
               :rules="[
-                { validator: () => !!form.nation, message: t('recruit.onboarding.selfForm.validation.nation') },
+                {
+                  validator: () => !!form.nation,
+                  message: t('recruit.onboarding.selfForm.validation.nation'),
+                },
               ]"
               @click="openPicker('nation')"
             />
@@ -210,7 +212,7 @@
         </section>
 
         <section class="section">
-          <header class="section__title">
+          <header class="section__title mb8">
             {{ t('recruit.onboarding.selfForm.sections.work') }}
           </header>
           <van-cell-group inset>
@@ -365,23 +367,23 @@ const submitting = ref(false);
 const form = reactive({
   id: null,
   avatarId: '',
-  name: '',
-  age: '',
-  cardNo: '',
+  name: 'zn b',
+  age: '18',
+  cardNo: '330225199907304839',
   idCardFront: '',
   idCardBack: '',
-  mobile: '',
-  nation: '',
-  address: '',
-  education: '',
-  graduateSchool: '',
-  passportNumber: '',
-  companyId: '',
-  companyDict: '',
-  jobGradeDictCode: '',
-  positionDict: '',
-  workYear: '',
-  isAccommodation: '',
+  mobile: '15824423899',
+  nation: '汉族',
+  address: '测试街道',
+  education: '初中及以下',
+  graduateSchool: '小学生',
+  passportNumber: 'huzhao001',
+  companyId: '1901902647122264066',
+  companyDict: '昌科',
+  jobGradeDictCode: '0',
+  positionDict: '钳工',
+  workYear: '1年以下',
+  isAccommodation: '是',
   applyStatus: '',
 });
 
@@ -626,7 +628,6 @@ onMounted(async () => {
 
 <style scoped lang="scss">
 .recruit-onboarding-self {
-  padding-top: 46px;
   min-height: 100vh;
   background: #f5f7fa;
   display: flex;
@@ -637,6 +638,12 @@ onMounted(async () => {
     overflow-y: auto;
     padding: 16px 12px 80px;
     box-sizing: border-box;
+    .mb8 {
+      margin-bottom: 8px;
+    }
+    :deep(.van-cell-group) {
+      margin: 0;
+    }
   }
 
   &__footer {


### PR DESCRIPTION
## Summary
- add validation rules to every field in the onboarding self form so all inputs are required
- provide corresponding validation messages across zh-CN, en-US, and vi-VN locales

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691181dfc3a08327b121031a1203e2e9)