### PR TITLE
Fix SelfOutbound scan bubble trigger

### DIFF
--- a/src/components/dc-ui/components/ScanCode/index.vue
+++ b/src/components/dc-ui/components/ScanCode/index.vue
@@ -36,8 +36,16 @@
           </div>
         </div>
 
-        <!-- 底部按钮 -->
-        <van-button class="btn" type="success" block @click="handleManualClose">关闭</van-button>
+        <!-- 底部按钮（美化版） -->
+        <van-button
+          class="btn btn-close"
+          round
+          size="large"
+          icon="cross"
+          @click="handleManualClose"
+        >
+          关闭
+        </van-button>
       </div>
     </van-popup>
   </div>
@@ -524,15 +532,67 @@ export default {
     }
   }
 
+  /* 底部关闭按钮（渐变工具栏风格） */
   .btn {
     position: fixed;
     left: 0;
     right: 0;
     bottom: 0;
-    border-radius: 0;
     z-index: 10000;
-    /* 适配 iOS 安全区 */
-    padding-bottom: calc(env(safe-area-inset-bottom) + 10px);
+
+    /* 上圆角、下贴边 */
+    border: none;
+    border-radius: 16px 16px 0 0;
+
+    /* 高度 & 安全区 */
+    height: 56px;
+    padding: 0 16px;
+    padding-bottom: calc(env(safe-area-inset-bottom));
+
+    /* 质感：渐变 + 玻璃高光 + 阴影 */
+    background: linear-gradient(135deg, #34c759, #14b85a);
+    color: #fff;
+    box-shadow:
+      0 -8px 24px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+
+    /* 顶部分割线 */
+    &::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      height: 1px;
+      background: linear-gradient(90deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.06));
+      pointer-events: none;
+    }
+
+    /* 按压反馈 */
+    transition:
+      transform 0.12s ease,
+      filter 0.2s ease;
+    &:active {
+      transform: translateY(1px);
+      filter: brightness(0.95);
+    }
+
+    /* Vant 内部内容微调 */
+    :deep(.van-button__content) {
+      height: 100%;
+      justify-content: center;
+      gap: 6px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    :deep(.van-icon) {
+      font-size: 18px;
+    }
+  }
+
+  /* 细腻的玻璃态（可选） */
+  .btn.btn-close {
+    backdrop-filter: saturate(160%) blur(10px);
   }
 }
 </style>

--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -23,15 +23,12 @@
         <van-button type="success" @click="doAction('handleSearch')">
           <van-icon name="search" size="18" /> 查询
         </van-button>
-        <dc-scan-code
-          ref="scanCodeRef"
-          v-model="snCode"
-          @confirm="handleScanConfirm"
-          @error="handleScanError"
-        >
-          <van-button type="primary" @click="doAction('scanCode')">
-            <van-icon name="scan" size="18" />
-          </van-button>
+        <dc-scan-code v-model="snCode" @confirm="handleScanConfirm" @error="handleScanError">
+          <template #default="{ open, disabled, loading }">
+            <van-button type="primary" :loading="loading" :disabled="disabled" @click="open">
+              <van-icon name="scan" size="18" />
+            </van-button>
+          </template>
         </dc-scan-code>
       </div>
     </van-sticky>
@@ -429,7 +426,6 @@ function onNumberInput(item, val) {
 }
 
 /** 扫码/查询/提交 */
-const scanCodeRef = ref(null);
 
 function handleScanConfirm(val) {
   if (!val) return;
@@ -441,17 +437,6 @@ function handleScanError(error) {
   const message = error?.message || '';
   if (message.includes('取消') || message.toLowerCase().includes('cancel')) return;
   showToast({ type: 'fail', message: message || '扫码失败' });
-}
-
-function scanCode() {
-  scanCodeRef.value
-    ?.open?.()
-    .then((val) => {
-      handleScanConfirm(val);
-    })
-    .catch((error) => {
-      handleScanError(error);
-    });
 }
 
 function handleSearch() {
@@ -484,8 +469,8 @@ function handleSearch() {
 }
 
 function doAction(action) {
-  if (['scanCode', 'handleSearch', 'search'].includes(action)) {
-    return action === 'scanCode' ? scanCode() : handleSearch();
+  if (['handleSearch', 'search'].includes(action)) {
+    return handleSearch();
   }
   if (action === 'submit') {
     formRef.value?.validate?.().then(() => {

--- a/src/views/apps/NameplateBinding/index.vue
+++ b/src/views/apps/NameplateBinding/index.vue
@@ -83,22 +83,19 @@
     </div>
 
     <!-- 悬浮：扫码（只显示 icon；避开底部按钮） -->
-    <dc-scan-code
-      ref="scanCodeRef"
-      v-model="snCode"
-      @confirm="handleScanSuccess"
-      @error="handleScanError"
-    >
-      <van-floating-bubble
-        class="float-bubble"
-        :class="{ 'is-disabled': isScanning }"
-        :offset="scanBubbleOffset"
-        axis="xy"
-        magnetic="x"
-        @click="handleOpenScan"
-      >
-        <van-icon name="scan" size="22" />
-      </van-floating-bubble>
+    <dc-scan-code v-model="snCode" @confirm="handleScanSuccess" @error="handleScanError">
+      <template #default="{ open, disabled, loading }">
+        <van-floating-bubble
+          class="float-bubble"
+          :class="{ 'is-disabled': disabled || loading }"
+          :offset="scanBubbleOffset"
+          axis="xy"
+          magnetic="x"
+          @click="open"
+        >
+          <van-icon name="scan" size="22" />
+        </van-floating-bubble>
+      </template>
     </dc-scan-code>
   </div>
 </template>
@@ -109,8 +106,6 @@ import QrcodeVue from 'qrcode.vue';
 import { showConfirmDialog, showLoadingToast, showToast } from 'vant';
 import Api from '@/api';
 import { withBase } from '@/utils/util';
-
-const NAV_H = 46; // 固定 NavBar 高度
 
 // 页面状态
 const snCode = ref('');
@@ -136,8 +131,6 @@ const footerH = ref(96);
 
 // 仅保留扫码浮窗（不再有回到顶部）
 const scanBubbleOffset = ref({ x: 16, y: 120 });
-const isScanning = ref(false);
-const scanCodeRef = ref(null);
 
 const measureFooter = () => {
   footerH.value = footerRef.value?.offsetHeight || 96;
@@ -197,22 +190,6 @@ const handleScanSuccess = (code) => {
   if (!code) return;
   snCode.value = code;
   indeCode();
-};
-
-const handleOpenScan = () => {
-  if (isScanning.value) return;
-  isScanning.value = true;
-  scanCodeRef.value
-    ?.open?.()
-    .then((code) => {
-      handleScanSuccess(code);
-    })
-    .catch((error) => {
-      handleScanError(error);
-    })
-    .finally(() => {
-      isScanning.value = false;
-    });
 };
 
 // 查询 & 提交

--- a/src/views/apps/SelfOutbound/list.vue
+++ b/src/views/apps/SelfOutbound/list.vue
@@ -46,7 +46,15 @@
       @confirm="handleScanConfirm"
       @error="handleScanError"
     >
-      <van-floating-bubble axis="xy" icon="scan" magnetic />
+      <template #default="{ open, disabled }">
+        <van-floating-bubble
+          axis="xy"
+          icon="scan"
+          magnetic
+          :class="{ 'is-disabled': disabled }"
+          @click="open"
+        />
+      </template>
     </dc-scan-code>
 
     <van-popup
@@ -451,5 +459,10 @@ async function handleSubmit() {
     font-size: 12px;
     color: #646566;
   }
+}
+
+:deep(.van-floating-bubble.is-disabled) {
+  pointer-events: none;
+  opacity: 0.6;
 }
 </style>

--- a/src/views/apps/SelfOutbound/list.vue
+++ b/src/views/apps/SelfOutbound/list.vue
@@ -51,7 +51,7 @@
           axis="xy"
           icon="scan"
           magnetic
-          :class="{ 'is-disabled': disabled }"
+          :class="['self-outbound-list__scan-bubble', { 'is-disabled': disabled }]"
           @click="open"
         />
       </template>
@@ -459,6 +459,10 @@ async function handleSubmit() {
     font-size: 12px;
     color: #646566;
   }
+}
+
+:deep(.self-outbound-list__scan-bubble) {
+  bottom: calc(env(safe-area-inset-bottom) + 120px);
 }
 
 :deep(.van-floating-bubble.is-disabled) {

--- a/src/views/apps/WireInspection/Submit.vue
+++ b/src/views/apps/WireInspection/Submit.vue
@@ -14,14 +14,21 @@
           >
             <template #button>
               <dc-scan-code
-                ref="scanCodeRef"
                 v-model="form.locatorNo"
                 @confirm="handleLocatorScanSuccess"
                 @error="handleScanError"
               >
-                <van-button size="small" type="primary" @click="handleScanLocator">
-                  扫码
-                </van-button>
+                <template #default="{ open, disabled, loading }">
+                  <van-button
+                    size="small"
+                    type="primary"
+                    :loading="loading"
+                    :disabled="disabled"
+                    @click="open"
+                  >
+                    扫码
+                  </van-button>
+                </template>
               </dc-scan-code>
             </template>
           </van-field>
@@ -32,14 +39,22 @@
           <div class="section__actions">
             <van-button size="small" type="primary" plain @click="addRow()">新增行</van-button>
             <dc-scan-code
-              ref="rowScanRef"
               v-model="rowScanCode"
               @confirm="handleRowScanConfirm"
               @error="handleScanError"
             >
-              <van-button size="small" type="success" plain @click="handleScanRow">
-                扫码录入
-              </van-button>
+              <template #default="{ open, disabled, loading }">
+                <van-button
+                  size="small"
+                  type="success"
+                  plain
+                  :loading="loading"
+                  :disabled="disabled"
+                  @click="open"
+                >
+                  扫码录入
+                </van-button>
+              </template>
             </dc-scan-code>
           </div>
         </div>
@@ -145,8 +160,6 @@ const { proxy } = getCurrentInstance();
 const router = useRouter();
 
 const formRef = ref(null);
-const scanCodeRef = ref(null);
-const rowScanRef = ref(null);
 const rowScanCode = ref('');
 
 let uid = 0;
@@ -256,15 +269,6 @@ function handleLocatorScanSuccess(code) {
   form.locatorNo = code;
 }
 
-async function handleScanLocator() {
-  try {
-    const code = await scanCodeRef.value?.open?.();
-    handleLocatorScanSuccess(code);
-  } catch (err) {
-    handleScanError(err);
-  }
-}
-
 async function handleRowScanConfirm(code) {
   if (!code) return;
   try {
@@ -275,15 +279,6 @@ async function handleRowScanConfirm(code) {
     addRow({ ...data, drawQty: String(data?.drawQty ?? '') });
     showToast({ type: 'success', message: '扫码成功' });
     rowScanCode.value = '';
-  } catch (err) {
-    handleScanError(err);
-  }
-}
-
-async function handleScanRow() {
-  try {
-    const code = await rowScanRef.value?.open?.();
-    await handleRowScanConfirm(code);
   } catch (err) {
     handleScanError(err);
   }


### PR DESCRIPTION
## Summary
- ensure the Self Outbound scan floating bubble explicitly opens the scanner when tapped
- add disabled styling for the floating bubble to reflect loading state

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912e196691c8327a5c03c552106f74f)