### PR TITLE
Handle scan cancellation for WeChat SDK utilities

### DIFF
--- a/src/components/dc-ui/components/ScanCode/index.vue
+++ b/src/components/dc-ui/components/ScanCode/index.vue
@@ -151,13 +151,17 @@ export default {
 
           return await this.openH5Scan();
         } catch (error) {
-          // 用户主动取消时不再降级
-          if (this.isUserCancelError(error) || env === 'normal') {
-            throw this.normalizeError(error);
-          }
+          if (error?.code === 'SCAN_CANCELLED') {
+            return;
+          } else {
+            // 用户主动取消时不再降级
+            if (this.isUserCancelError(error) || env === 'normal') {
+              throw this.normalizeError(error);
+            }
 
-          console.warn('[dc-scan-code] SDK 扫码失败，尝试切换为 H5 扫码', error);
-          return this.openH5Scan();
+            console.warn('[dc-scan-code] SDK 扫码失败，尝试切换为 H5 扫码', error);
+            return this.openH5Scan();
+          }
         }
       };
 

--- a/src/utils/wwxsdk.js
+++ b/src/utils/wwxsdk.js
@@ -74,20 +74,31 @@ export function wwScanQRCode(options = {}, success, error) {
       needResult: scanOptions.needResult,
       success: function (res) {
         if (isScanCancelled(res)) {
-          console.log('企业微信扫码已取消:', res);
+          error(
+            Object.assign(new Error('企业微信扫码已取消'), {
+              code: 'SCAN_CANCELLED',
+              detail: res,
+            })
+          );
           return;
         }
-
         if (typeof success === 'function') {
           success(res);
         }
       },
       cancel: function (res) {
         console.log('企业微信扫码取消:', res);
+        error(
+          Object.assign(new Error('企业微信扫码已取消'), {
+            code: 'SCAN_CANCELLED',
+            detail: res,
+          })
+        );
       },
       error: function (err) {
+        console.error('企业微信扫码失败:', err);
         if (typeof error === 'function') {
-          error(err);
+          reject({ code: 'error', detail: err });
         }
       },
     });
@@ -110,7 +121,12 @@ export function wwScanQRCode(options = {}, success, error) {
         success: function (res) {
           console.log('企业微信扫码成功:', res);
           if (isScanCancelled(res)) {
-            reject(Object.assign(new Error('企业微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res }));
+            reject(
+              Object.assign(new Error('企业微信扫码已取消'), {
+                code: 'SCAN_CANCELLED',
+                detail: res,
+              })
+            );
             return;
           }
 
@@ -118,11 +134,13 @@ export function wwScanQRCode(options = {}, success, error) {
         },
         cancel: function (res) {
           console.log('企业微信扫码取消:', res);
-          reject(Object.assign(new Error('企业微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res }));
+          reject(
+            Object.assign(new Error('企业微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res })
+          );
         },
         error: function (err) {
           console.error('企业微信扫码失败:', err);
-          reject(err);
+          reject({ code: 'error', detail: err });
         },
       });
     } catch (error) {

--- a/src/utils/wwxsdk.js
+++ b/src/utils/wwxsdk.js
@@ -75,9 +75,6 @@ export function wwScanQRCode(options = {}, success, error) {
       success: function (res) {
         if (isScanCancelled(res)) {
           console.log('企业微信扫码已取消:', res);
-          if (typeof error === 'function') {
-            error(res);
-          }
           return;
         }
 
@@ -87,9 +84,6 @@ export function wwScanQRCode(options = {}, success, error) {
       },
       cancel: function (res) {
         console.log('企业微信扫码取消:', res);
-        if (typeof error === 'function') {
-          error(res);
-        }
       },
       error: function (err) {
         if (typeof error === 'function') {

--- a/src/utils/wxsdk.js
+++ b/src/utils/wxsdk.js
@@ -5,14 +5,14 @@ import wx from 'weixin-js-sdk';
 import commonApi from '@/api/modules/common';
 
 function isScanCancelled(res) {
-    if (!res || typeof res !== 'object') {
-        return false;
-    }
+  if (!res || typeof res !== 'object') {
+    return false;
+  }
 
-    const errInfo = String(res.err_Info || '').toLowerCase();
-    const errMsg = String(res.errMsg || '').toLowerCase();
+  const errInfo = String(res.err_Info || '').toLowerCase();
+  const errMsg = String(res.errMsg || '').toLowerCase();
 
-    return errInfo === 'cancel' || errMsg.includes(':cancel');
+  return errInfo === 'cancel' || errMsg.includes(':cancel');
 }
 
 /**
@@ -22,28 +22,28 @@ function isScanCancelled(res) {
  * @param {Function} error - 初始化失败回调
  */
 export function initWxSDK(config, success, error) {
-    wx.config({
-        debug: false, // 开启调试模式
-        appId: config.appId, // 必填，公众号的唯一标识
-        timestamp: config.timestamp, // 必填，生成签名的时间戳
-        nonceStr: config.nonceStr, // 必填，生成签名的随机串
-        signature: config.signature, // 必填，签名
-        jsApiList: config.jsApiList || ['scanQRCode'], // 必填，需要使用的JS接口列表
-    });
+  wx.config({
+    debug: false, // 开启调试模式
+    appId: config.appId, // 必填，公众号的唯一标识
+    timestamp: config.timestamp, // 必填，生成签名的时间戳
+    nonceStr: config.nonceStr, // 必填，生成签名的随机串
+    signature: config.signature, // 必填，签名
+    jsApiList: config.jsApiList || ['scanQRCode'], // 必填，需要使用的JS接口列表
+  });
 
-    wx.ready(() => {
-        console.log('微信JS-SDK初始化成功');
-        if (typeof success === 'function') {
-            success(wx);
-        }
-    });
+  wx.ready(() => {
+    console.log('微信JS-SDK初始化成功');
+    if (typeof success === 'function') {
+      success(wx);
+    }
+  });
 
-    wx.error((res) => {
-        console.error('微信JS-SDK初始化失败:', res);
-        if (typeof error === 'function') {
-            error(res);
-        }
-    });
+  wx.error((res) => {
+    console.error('微信JS-SDK初始化失败:', res);
+    if (typeof error === 'function') {
+      error(res);
+    }
+  });
 }
 
 /**
@@ -52,7 +52,7 @@ export function initWxSDK(config, success, error) {
  * @returns {Promise} 返回微信配置信息
  */
 export function getWxConfig(url) {
-    return commonApi.wechat.getWxConfig(url);
+  return commonApi.wechat.getWxConfig(url);
 }
 
 /**
@@ -64,26 +64,26 @@ export function getWxConfig(url) {
  * @param {String} shareData.imgUrl - 分享图标
  */
 export function setWxShare(shareData) {
-    // 更新朋友圈分享
-    wx.updateTimelineShareData({
-        title: shareData.title,
-        link: shareData.link,
-        imgUrl: shareData.imgUrl,
-        success: function () {
-            console.log('设置朋友圈分享成功');
-        },
-    });
+  // 更新朋友圈分享
+  wx.updateTimelineShareData({
+    title: shareData.title,
+    link: shareData.link,
+    imgUrl: shareData.imgUrl,
+    success: function () {
+      console.log('设置朋友圈分享成功');
+    },
+  });
 
-    // 更新朋友分享
-    wx.updateAppMessageShareData({
-        title: shareData.title,
-        desc: shareData.desc,
-        link: shareData.link,
-        imgUrl: shareData.imgUrl,
-        success: function () {
-            console.log('设置朋友分享成功');
-        },
-    });
+  // 更新朋友分享
+  wx.updateAppMessageShareData({
+    title: shareData.title,
+    desc: shareData.desc,
+    link: shareData.link,
+    imgUrl: shareData.imgUrl,
+    success: function () {
+      console.log('设置朋友分享成功');
+    },
+  });
 }
 
 /**
@@ -94,73 +94,94 @@ export function setWxShare(shareData) {
  * @returns {Promise} 返回Promise对象（新版本）
  */
 export function wxScanQRCode(options = {}, success, error) {
-    // 默认配置
-    const defaultOptions = {
-        needResult: 1, // 默认为0，扫描结果由微信处理，1则直接返回扫描结果
-        scanType: ['qrCode', 'barCode'], // 可以指定扫二维码还是一维码，默认二者都有
-    };
+  // 默认配置
+  const defaultOptions = {
+    needResult: 1, // 默认为0，扫描结果由微信处理，1则直接返回扫描结果
+    scanType: ['qrCode', 'barCode'], // 可以指定扫二维码还是一维码，默认二者都有
+  };
 
-    // 合并配置
-    const scanOptions = Object.assign({}, defaultOptions, options);
+  // 合并配置
+  const scanOptions = Object.assign({}, defaultOptions, options);
 
-    // // 如果传入了回调函数，则使用回调模式（兼容旧版本）
-    if (typeof success === 'function' || typeof error === 'function') {
-        wx.scanQRCode({
-            needResult: scanOptions.needResult,
-            scanType: scanOptions.scanType,
-            success: function (res) {
-                if (isScanCancelled(res)) {
-                    console.log('微信扫码已取消:', res);
-                    return;
-                }
-
-                if (typeof success === 'function') {
-                    success(res);
-                }
-            },
-            cancel: function (res) {
-                console.log('微信扫码取消:', res);
-            },
-            error: function (err) {
-                if (typeof error === 'function') {
-                    error(err);
-                }
-            },
-        });
-        return; // 回调模式不返回Promise
-    }
-
-    // 否则返回Promise对象（新版本）
-    return new Promise((resolve, reject) => {
-        try {
-            // 检查微信SDK是否已初始化
-            if (!wx || typeof wx.scanQRCode !== 'function') {
-                reject(new Error('微信SDK未初始化或scanQRCode方法不可用'));
-                return;
-            }
-
-            wx.scanQRCode({
-                needResult: scanOptions.needResult,
-                scanType: scanOptions.scanType,
-                success: function (res) {
-                    console.log('微信扫码成功:', res);
-                    if (isScanCancelled(res)) {
-                        reject(Object.assign(new Error('微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res }));
-                        return;
-                    }
-
-                    resolve(res);
-                },
-                error: function (err) {
-                    console.error('微信扫码失败:', err);
-                    reject(err);
-                },
-            });
-        } catch (error) {
-            console.error('调用微信扫码API时发生异常:', error);
-            reject(error);
+  // // 如果传入了回调函数，则使用回调模式（兼容旧版本）
+  if (typeof success === 'function' || typeof error === 'function') {
+    wx.scanQRCode({
+      needResult: scanOptions.needResult,
+      scanType: scanOptions.scanType,
+      success: function (res) {
+        if (isScanCancelled(res)) {
+          console.log('微信扫码已取消:', res);
+          error(
+            Object.assign(new Error('微信扫码已取消'), {
+              code: 'SCAN_CANCELLED',
+              detail: res,
+            })
+          );
+          return;
         }
+
+        if (typeof success === 'function') {
+          success(res);
+        }
+      },
+      cancel: function (res) {
+        console.log('微信扫码取消:', res);
+        error(
+          Object.assign(new Error('微信扫码已取消'), {
+            code: 'SCAN_CANCELLED',
+            detail: res,
+          })
+        );
+      },
+      error: function (err) {
+        console.error('微信扫码失败:', err);
+        if (typeof error === 'function') {
+          reject({ code: 'error', detail: err });
+        }
+      },
     });
+    return; // 回调模式不返回Promise
+  }
+
+  // 否则返回Promise对象（新版本）
+  return new Promise((resolve, reject) => {
+    try {
+      // 检查微信SDK是否已初始化
+      if (!wx || typeof wx.scanQRCode !== 'function') {
+        reject(new Error('微信SDK未初始化或scanQRCode方法不可用'));
+        return;
+      }
+
+      wx.scanQRCode({
+        needResult: scanOptions.needResult,
+        scanType: scanOptions.scanType,
+        success: function (res) {
+          console.log('微信扫码成功:', res);
+          if (isScanCancelled(res)) {
+            reject(
+              Object.assign(new Error('微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res })
+            );
+            return;
+          }
+
+          resolve(res);
+        },
+        cancel: function (res) {
+          console.log('微信扫码取消:', res);
+          reject(
+            Object.assign(new Error('微信扫码已取消'), { code: 'SCAN_CANCELLED', detail: res })
+          );
+        },
+        error: function (err) {
+          console.error('微信扫码失败:', err);
+          reject({ code: 'error', detail: err });
+        },
+      });
+    } catch (error) {
+      console.error('调用微信扫码API时发生异常:', error);
+      reject(error);
+    }
+  });
 }
 
 /**
@@ -169,19 +190,19 @@ export function wxScanQRCode(options = {}, success, error) {
  * @param {Function} error - 失败回调
  */
 export function wxGetLocation(success, error) {
-    wx.getLocation({
-        type: 'wgs84', // 默认为wgs84的gps坐标，如果要返回直接给openLocation用的火星坐标，可传入'gcj02'
-        success: function (res) {
-            if (typeof success === 'function') {
-                success(res);
-            }
-        },
-        error: function (err) {
-            if (typeof error === 'function') {
-                error(err);
-            }
-        },
-    });
+  wx.getLocation({
+    type: 'wgs84', // 默认为wgs84的gps坐标，如果要返回直接给openLocation用的火星坐标，可传入'gcj02'
+    success: function (res) {
+      if (typeof success === 'function') {
+        success(res);
+      }
+    },
+    error: function (err) {
+      if (typeof error === 'function') {
+        error(err);
+      }
+    },
+  });
 }
 
 /**
@@ -191,21 +212,21 @@ export function wxGetLocation(success, error) {
  * @param {Function} error - 失败回调
  */
 export function wxChooseImage(options = {}, success, error) {
-    wx.chooseImage({
-        count: options.count || 1, // 默认9
-        sizeType: options.sizeType || ['original', 'compressed'], // 可以指定是原图还是压缩图，默认二者都有
-        sourceType: options.sourceType || ['album', 'camera'], // 可以指定来源是相册还是相机，默认二者都有
-        success: function (res) {
-            if (typeof success === 'function') {
-                success(res);
-            }
-        },
-        error: function (err) {
-            if (typeof error === 'function') {
-                error(err);
-            }
-        },
-    });
+  wx.chooseImage({
+    count: options.count || 1, // 默认9
+    sizeType: options.sizeType || ['original', 'compressed'], // 可以指定是原图还是压缩图，默认二者都有
+    sourceType: options.sourceType || ['album', 'camera'], // 可以指定来源是相册还是相机，默认二者都有
+    success: function (res) {
+      if (typeof success === 'function') {
+        success(res);
+      }
+    },
+    error: function (err) {
+      if (typeof error === 'function') {
+        error(err);
+      }
+    },
+  });
 }
 
 // 导出wx对象，以便直接使用

--- a/src/utils/wxsdk.js
+++ b/src/utils/wxsdk.js
@@ -111,15 +111,15 @@ export function wxScanQRCode(options = {}, success, error) {
             success: function (res) {
                 if (isScanCancelled(res)) {
                     console.log('微信扫码已取消:', res);
-                    if (typeof error === 'function') {
-                        error(res);
-                    }
                     return;
                 }
 
                 if (typeof success === 'function') {
                     success(res);
                 }
+            },
+            cancel: function (res) {
+                console.log('微信扫码取消:', res);
             },
             error: function (err) {
                 if (typeof error === 'function') {


### PR DESCRIPTION
## Summary
- detect user-initiated cancellations in both WeChat and WeCom scan helpers
- prevent updating scan results when cancelled and propagate cancellation through errors/rejections

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ef997450832791e6537a9017ddaa)