### PR TITLE
Refactor navigation bars to use dc wrapper

### DIFF
--- a/src/components/dc-ui/components/NavBar/index.vue
+++ b/src/components/dc-ui/components/NavBar/index.vue
@@ -1,8 +1,5 @@
 <template>
-  <van-nav-bar
-    v-bind="attrs"
-    :class="['scroll-aware-nav-bar', { 'scroll-aware-nav-bar--hidden': isHidden }]"
-  >
+  <van-nav-bar v-bind="forwardedAttrs">
     <template v-for="(_, name) in $slots" #[name]="slotProps">
       <slot :name="name" v-bind="slotProps"></slot>
     </template>
@@ -10,37 +7,25 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { computed } from 'vue';
 import { useAttrs } from 'vue';
-import { detectWxEnv, isWxMiniProgram } from './../../util/wx-env'; // 路径按你的实际调整
+
+defineOptions({ name: 'DcNavBar' });
 
 const attrs = useAttrs();
 
-// 你原来的滚动隐藏状态（若外部有控制可对接/替换）
-const isHidden = ref(false);
+const forwardedAttrs = computed(() => {
+  const { fixed: _fixed, placeholder: _placeholder, class: className, ...rest } = attrs;
 
-// 环境决定的隐藏（微信/企业微信/小程序）
-const hideByEnv = ref(false);
-
-onMounted(async () => {
-  const env = detectWxEnv();
-  // 在微信或企业微信内置浏览器下隐藏
-  hideByEnv.value = env.isWeChat || env.isWeCom;
-
-  // 如果你也希望在“小程序 Web-View”里隐藏，保留下面这段；不需要则删掉
-  if (!hideByEnv.value) {
-    hideByEnv.value = await isWxMiniProgram();
-  }
+  return {
+    ...rest,
+    class: ['dc-nav-bar', className].filter(Boolean),
+  };
 });
 </script>
 
 <style scoped>
-.scroll-aware-nav-bar {
-  transition: transform 0.3s ease;
-  will-change: transform;
-}
-
-.scroll-aware-nav-bar--hidden {
-  transform: translateY(-100%);
+.dc-nav-bar {
+  position: relative;
 }
 </style>

--- a/src/components/dc-ui/components/Pagination/index.vue
+++ b/src/components/dc-ui/components/Pagination/index.vue
@@ -178,7 +178,7 @@ const props = defineProps({
   offset: { type: Number, default: 200 },
   immediate: { type: Boolean, default: true },
   itemKey: { type: Function, default: (item, idx) => item?.id ?? item?.no ?? idx },
-  navSelector: { type: String, default: '.van-nav-bar--fixed' },
+  navSelector: { type: String, default: '.dc-nav-bar' },
   getNavEl: { type: Function, default: null },
   backTopThreshold: { type: Number, default: 300 },
   addVisible: { type: Boolean, default: true },
@@ -242,7 +242,11 @@ let headerResizeObs = null;
 const resolveNavEl = () => {
   if (typeof props.getNavEl === 'function') return props.getNavEl();
   if (props.navSelector) return document.querySelector(props.navSelector);
-  return document.querySelector('.van-nav-bar--fixed') || document.querySelector('.nav-primary');
+  return (
+    document.querySelector('.dc-nav-bar') ||
+    document.querySelector('.van-nav-bar') ||
+    document.querySelector('.nav-primary')
+  );
 };
 
 const measureAndApplyTop = () => {

--- a/src/views/account/Me.vue
+++ b/src/views/account/Me.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page mine">
     <div class="top-bg"></div>
-    <van-nav-bar :title="t('me.navTitle')" :border="false" class="mine-nav" safe-area-inset-top />
+    <dc-nav-bar :title="t('me.navTitle')" :border="false" class="mine-nav" safe-area-inset-top />
     <section class="profile-card">
       <div class="bg-index bg-index-2"></div>
       <div class="bg-index bg-index-1"></div>

--- a/src/views/account/me/WorkTime.vue
+++ b/src/views/account/me/WorkTime.vue
@@ -1,18 +1,14 @@
 <template>
   <div class="me-work-time">
-    <!-- 顶部固定导航 -->
-    <van-nav-bar
+    <!-- 顶部导航 -->
+    <dc-nav-bar
       class="me-work-time__nav"
       :title="t('me.workTime.title')"
       left-arrow
-      fixed
       :border="false"
       safe-area-inset-top
-      placeholder
       @click-left="handleBack"
     />
-    <!-- 占位：确保内容不被固定导航遮挡（若 van-nav-bar 已内置 placeholder 可删除本行） -->
-    <div class="me-work-time__nav-spacer" aria-hidden="true"></div>
 
     <main class="me-work-time__body">
       <!-- 日期卡片：月视图 / 周视图（收起） -->
@@ -219,11 +215,6 @@ watch(
 </script>
 
 <style scoped lang="scss">
-/* 统一定义导航高度，若你的 van-nav-bar 高度不同，请在此处调整 */
-:root {
-  --dc-nav-height: 46px;
-}
-
 .me-work-time {
   min-height: 100vh;
   background: #f7f8fa;
@@ -233,23 +224,11 @@ watch(
   position: relative;
 
   &__nav {
-    /* 强制固定到顶部（即使外层没正确传 fixed 或被覆盖也能兜底） */
-    position: fixed !important;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000; /* 覆盖下方内容与弹层 */
-    background: #fff; /* 若需要透明，可改为 transparent */
-  }
-
-  /* 占位，避免主内容被固定导航遮挡 */
-  &__nav-spacer {
-    height: calc(var(--dc-nav-height) + env(safe-area-inset-top));
-    height: calc(var(--dc-nav-height) + constant(safe-area-inset-top));
+    background: #fff;
   }
 
   &__body {
-    margin-top: 46px;
+    margin-top: 16px;
     display: flex;
     flex-direction: column;
     row-gap: 12px;

--- a/src/views/apps/InboundOrder/Create.vue
+++ b/src/views/apps/InboundOrder/Create.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="cnt">
     <!-- 顶部导航 -->
-    <van-nav-bar ref="navRef" title="新增入库单" fixed left-arrow @click-left="goBack" />
+    <dc-nav-bar ref="navRef" title="新增入库单" left-arrow @click-left="goBack" />
 
     <!-- 基本信息 -->
     <div class="base-wrapper mtop20">

--- a/src/views/apps/InboundOrder/Detail.vue
+++ b/src/views/apps/InboundOrder/Detail.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page inbound-order-detail">
-    <van-nav-bar ref="navRef" title="入库单详情" fixed left-arrow @click-left="goBack" />
+    <dc-nav-bar ref="navRef" title="入库单详情" left-arrow @click-left="goBack" />
 
     <!-- 加载态 -->
     <div v-if="loading" class="page-body">

--- a/src/views/apps/InboundOrder/List.vue
+++ b/src/views/apps/InboundOrder/List.vue
@@ -14,7 +14,7 @@
       @add="handleCreate"
     >
       <template #nav>
-        <van-nav-bar ref="navRef" title="入库单" fixed left-arrow @click-left="goBack" />
+        <dc-nav-bar ref="navRef" title="入库单" left-arrow @click-left="goBack" />
       </template>
 
       <template #item="{ item, index }">

--- a/src/views/apps/MaterialMaintenance/index.vue
+++ b/src/views/apps/MaterialMaintenance/index.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="page-container page-material-info">
     <!-- 顶部栏 -->
-    <van-nav-bar ref="navRef" title="物料信息维护" left-arrow @click-left="handleBack" />
+    <dc-nav-bar ref="navRef" title="物料信息维护" left-arrow @click-left="handleBack" />
     <!-- 搜索区（吸顶） -->
     <van-sticky
       :offset-top="stickyTop"

--- a/src/views/apps/NameplateBinding/index.vue
+++ b/src/views/apps/NameplateBinding/index.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="nameplate-binding">
     <!-- 顶部导航 -->
-    <van-nav-bar left-arrow title="铭牌绑定" class="np-navbar" @click-left="handleBack" />
+    <dc-nav-bar left-arrow title="铭牌绑定" class="np-navbar" @click-left="handleBack" />
 
     <!-- 内容（搜索不吸顶） -->
     <div class="nameplate-binding__content">

--- a/src/views/apps/SelfOutbound/list.vue
+++ b/src/views/apps/SelfOutbound/list.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="self-outbound-list">
-    <van-nav-bar title="自助出库" left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="自助出库" left-arrow @click-left="handleBack" />
 
     <div class="self-outbound-list__body">
       <van-form class="self-outbound-list__form" :model="form">

--- a/src/views/apps/SelfOutbound/submit.vue
+++ b/src/views/apps/SelfOutbound/submit.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="self-outbound-submit">
-    <van-nav-bar title="出库提交" left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="出库提交" left-arrow @click-left="handleBack" />
     <div class="self-outbound-submit__body">
       <van-empty description="表单配置暂未完成" />
     </div>

--- a/src/views/apps/SitePlanning/Create.vue
+++ b/src/views/apps/SitePlanning/Create.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="site-planning-create">
-    <van-nav-bar title="现场计划单" fixed left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="现场计划单" left-arrow @click-left="handleBack" />
 
     <div class="base-wrapper ptop56">
       <div class="baseinfo">
@@ -154,7 +154,7 @@ async function handleSave() {
   box-sizing: border-box;
 
   .ptop56 {
-    margin-top: 56px;
+    margin-top: 24px;
   }
 
   .base-wrapper {

--- a/src/views/apps/WireInspection/List.vue
+++ b/src/views/apps/WireInspection/List.vue
@@ -10,7 +10,7 @@
       @add="handleCreate"
     >
       <template #nav>
-        <van-nav-bar ref="navRef" title="线材质检" fixed left-arrow @click-left="goBack" />
+        <dc-nav-bar ref="navRef" title="线材质检" left-arrow @click-left="goBack" />
       </template>
 
       <template #item="{ item, index }">

--- a/src/views/apps/WireInspection/Submit.vue
+++ b/src/views/apps/WireInspection/Submit.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page wire-inspection-submit">
-    <van-nav-bar title="线材质检" left-arrow fixed @click-left="goBack" />
+    <dc-nav-bar title="线材质检" left-arrow @click-left="goBack" />
 
     <div class="wire-inspection-submit__body">
       <van-form ref="formRef" :model="form" scroll-to-error>

--- a/src/views/apps/WorkReport/MissingMaterial.vue
+++ b/src/views/apps/WorkReport/MissingMaterial.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="missing-material page">
-    <van-nav-bar title="缺料明细" left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="缺料明细" left-arrow @click-left="handleBack" />
 
     <div class="missing-material__content">
       <div v-if="dataList.length" class="missing-material__scroll">

--- a/src/views/apps/WorkReport/WorkReport.vue
+++ b/src/views/apps/WorkReport/WorkReport.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="work-report page">
-    <van-nav-bar title="工时汇报" left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="工时汇报" left-arrow @click-left="handleBack" />
 
     <div class="work-report__content">
       <!-- 普通白卡：搜索 + 扫码（不吸顶） -->

--- a/src/views/apps/components/AppPage.vue
+++ b/src/views/apps/components/AppPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page app-page">
-    <van-nav-bar :title="title" fixed />
+    <dc-nav-bar :title="title" />
     <div class="app-page__content">
       <van-empty :description="description" />
     </div>
@@ -31,7 +31,7 @@ const { title, description } = toRefs(props);
 }
 
 .app-page__content {
-  min-height: calc(100vh - 96px);
+  min-height: calc(100vh - 56px);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/views/apps/confirmMaterial/index.vue
+++ b/src/views/apps/confirmMaterial/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="confirm-material">
-    <van-nav-bar ref="navRef" title="确认领料" left-arrow @click-left="handleBack" />
+    <dc-nav-bar ref="navRef" title="确认领料" left-arrow @click-left="handleBack" />
     <div class="confirm-material__content">
       <van-sticky ref="stickyRef" :offset-top="tabsOffsetTop" class="confirm-material__sticky">
         <div ref="stickyInnerRef">

--- a/src/views/apps/index.vue
+++ b/src/views/apps/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="dc-apps page">
-    <van-nav-bar :title="t('routes.apps')" fixed />
+    <dc-nav-bar :title="t('routes.apps')" />
 
     <div class="dc-apps__content">
       <van-grid class="dc-apps__grid" :column-num="4" :gutter="12" clickable :border="false">
@@ -80,7 +80,7 @@ const apps = [
 
   &__content {
     padding: 24px 16px;
-    padding-top: calc(72px + var(--van-safe-area-top, 0px));
+    padding-top: calc(24px + var(--van-safe-area-top, 0px));
     box-sizing: border-box;
   }
 

--- a/src/views/home/index.vue
+++ b/src/views/home/index.vue
@@ -1,7 +1,7 @@
 <!-- pages/CascaderDemo.vue -->
 <template>
   <div class="page home">
-    <van-nav-bar :title="t('routes.home')" fixed />
+    <dc-nav-bar :title="t('routes.home')" />
   </div>
 </template>
 

--- a/src/views/recruit/campus/apply-detail.vue
+++ b/src/views/recruit/campus/apply-detail.vue
@@ -1,5 +1,5 @@
 <template>
-  <van-nav-bar title="投递详情" fixed placeholder left-arrow @click-left="onClickLeft" />
+  <dc-nav-bar title="投递详情" left-arrow @click-left="onClickLeft" />
 
   <div class="page">
     <div class="page-top-bg"></div>

--- a/src/views/recruit/campus/apply.vue
+++ b/src/views/recruit/campus/apply.vue
@@ -1,13 +1,13 @@
 <!-- src/views/recruit/campus/apply.vue -->
 <template>
-  <van-nav-bar title="简历投递" @click-right="onClickRight">
+  <dc-nav-bar title="简历投递" @click-right="onClickRight">
     <template #right>
       <span class="help">
         帮助文档
         <van-icon name="question-o" size="18" />
       </span>
     </template>
-  </van-nav-bar>
+  </dc-nav-bar>
   <img class="banner" :src="$assetUrl('/images/recruit/campus/apply/banner.svg')" alt="banner" />
   <dc-recruit-form
     v-model="form"

--- a/src/views/settings/DebugSettings.vue
+++ b/src/views/settings/DebugSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="debug-settings">
-    <van-nav-bar title="调试设置" left-arrow @click-left="handleBack" />
+    <dc-nav-bar title="调试设置" left-arrow @click-left="handleBack" />
 
     <section class="debug-settings__content">
       <van-cell-group inset>

--- a/src/views/sop/doc.vue
+++ b/src/views/sop/doc.vue
@@ -1,5 +1,5 @@
 <template>
-  <van-nav-bar title="东创知识库" left-arrow @click-left="onClickLeft" />
+  <dc-nav-bar title="东创知识库" left-arrow @click-left="onClickLeft" />
   <div class="page-sop-doc dc-sop-doc">
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div class="contents" v-html="contentHtml"></div>


### PR DESCRIPTION
## Summary
- wrap the Vant nav bar in the dc-ui NavBar component so it can standardize attributes and styling
- replace legacy `<van-nav-bar>` usage across the app with `<dc-nav-bar>` and tweak affected page layouts for non-fixed headers
- update pagination helpers to detect the new navigation component when measuring header offsets

## Testing
- npm run lint *(fails: repository already contains unrelated lint errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912fbf093d08327bceeef9d05be7d52)