### PR TITLE
Fix workflow module imports and dependencies

### DIFF
--- a/src/components/dc/renderer/RendererComparePanel.vue
+++ b/src/components/dc/renderer/RendererComparePanel.vue
@@ -1,0 +1,57 @@
+<template>
+  <wf-form
+    v-model="formValue"
+    :option="option"
+    @submit="handleSubmit"
+  >
+    <template #menu>
+      <slot name="menu" />
+    </template>
+    <slot />
+  </wf-form>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+import WfForm from '@/components/wf-ui/components/wf-form/wf-form.vue';
+
+export default defineComponent({
+  name: 'RendererComparePanel',
+  components: { WfForm },
+  props: {
+    modelValue: {
+      type: Object,
+      default: () => ({}),
+    },
+    option: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue', 'submit'],
+  data() {
+    return {
+      formValue: { ...this.modelValue },
+    };
+  },
+  watch: {
+    modelValue: {
+      deep: true,
+      handler(value) {
+        this.formValue = { ...(value || {}) };
+      },
+    },
+    formValue: {
+      deep: true,
+      handler(value) {
+        this.$emit('update:modelValue', value);
+      },
+    },
+  },
+  methods: {
+    handleSubmit(form, done) {
+      this.$emit('submit', form, done);
+    },
+  },
+});
+</script>

--- a/src/components/wf-ui/components/wf-form-item/wf-form-item.vue
+++ b/src/components/wf-ui/components/wf-form-item/wf-form-item.vue
@@ -186,11 +186,11 @@
 </template>
 
 <script>
-import WfFeasibility from '@/pages/plugin/workflow/components/wf-feasibility/wf-feasibility.vue';
-import WfUserSelect from '@/pages/plugin/workflow/components/custom-fileds/wf-user-select/index.vue';
-import Customtable from '@/pages/plugin/workflow/components/custom-fileds/wf-customtable-select/index.vue';
-import MaterialTable from '@/pages/plugin/workflow/components/custom-fileds/wf-material-select/index.vue';
-import Vaguecustomtableselect from '@/pages/plugin/workflow/components/custom-fileds/wf-fuzzymaterial-select/index.vue';
+import WfFeasibility from '@/views/plugin/workflow/components/wf-feasibility/wf-feasibility.vue';
+import WfUserSelect from '@/views/plugin/workflow/components/custom-fileds/wf-user-select/index.vue';
+import Customtable from '@/views/plugin/workflow/components/custom-fileds/wf-customtable-select/index.vue';
+import MaterialTable from '@/views/plugin/workflow/components/custom-fileds/wf-material-select/index.vue';
+import Vaguecustomtableselect from '@/views/plugin/workflow/components/custom-fileds/wf-fuzzymaterial-select/index.vue';
 import { DATE_LIST } from '../../util/variable.js';
 import { mpFormInitVal } from '../../util/dataformat.js';
 

--- a/src/components/wf-ui/components/wf-sign/wf-sign.vue
+++ b/src/components/wf-ui/components/wf-sign/wf-sign.vue
@@ -24,7 +24,7 @@
 
 <script>
 import { defineComponent } from 'vue';
-import { Button, Image as VanImage } from 'vant';
+import { Button, Image as VanImage, showToast } from 'vant';
 import Props from '../../mixins/props.js';
 import SignaturePad from './components/signature.vue';
 import { DIC_HTTP_PROPS } from '../../util/variable.js';
@@ -99,11 +99,7 @@ export default defineComponent({
           const message = '未配置上传地址，保存为base64';
           const tag = sessionStorage.getItem(this.signId);
           if (!tag) {
-            uni.showToast({
-              title: message,
-              icon: 'none',
-              position: 'bottom',
-            });
+            showToast({ message, position: 'bottom' });
             sessionStorage.setItem(this.signId, 1);
           }
           reject();

--- a/src/components/wf-ui/util/dataformat.js
+++ b/src/components/wf-ui/util/dataformat.js
@@ -1,6 +1,5 @@
 import { validateNull, detailDataType, findObject, createObj } from './index.js';
 import {
-    KEY_COMPONENT_NAME,
     DIC_SPLIT,
     ARRAY_LIST,
     DATE_LIST,

--- a/src/store/workflow.js
+++ b/src/store/workflow.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { todoList } from '@/pages/plugin/workflow/api/process.js';
+import { todoList } from '@/views/plugin/workflow/api/process.js';
 
 export const useWorkflowStore = defineStore('workflow', {
   state: () => ({

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -1,0 +1,4 @@
+import { Base64 } from 'js-base64';
+
+export { Base64 };
+export default Base64;

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -36,3 +36,12 @@ export function getLoginEnv(ua) {
 
 // 若项目里曾用过 getLoginEnvSync，这里做个别名兼容
 export const getLoginEnvSync = getLoginEnv;
+
+export function isRendererTestEnvironment() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const search = window.location?.search || '';
+  const hash = window.location?.hash || '';
+  return /rendererCompare=true/i.test(search) || /rendererCompare=true/i.test(hash);
+}

--- a/src/uview-ui/libs/util/async-validator.js
+++ b/src/uview-ui/libs/util/async-validator.js
@@ -1,0 +1,42 @@
+class Schema {
+  constructor(rules = {}) {
+    this.rules = rules;
+  }
+
+  async validate(source = {}, options = {}) {
+    const firstFields = options.firstFields === true;
+    const errors = [];
+    const fields = {};
+
+    Object.keys(this.rules || {}).forEach((field) => {
+      const rawRules = this.rules[field];
+      const ruleList = Array.isArray(rawRules) ? rawRules : rawRules ? [rawRules] : [];
+      ruleList.forEach((rule) => {
+        if (!rule) return;
+        const value = source[field];
+        const isEmpty = value === undefined || value === null || value === '';
+        if (rule.required && isEmpty) {
+          const message = rule.message || `${field} is required`;
+          const error = { field, message, rule };
+          errors.push(error);
+          if (!fields[field]) {
+            fields[field] = [];
+          }
+          fields[field].push(error);
+        }
+      });
+    });
+
+    if (errors.length) {
+      if (firstFields) {
+        const firstError = errors[0];
+        return Promise.reject({ errors: [firstError], fields: { [firstError.field]: [firstError] } });
+      }
+      return Promise.reject({ errors, fields });
+    }
+
+    return Promise.resolve(source);
+  }
+}
+
+export default Schema;

--- a/src/views/plugin/workflow/api/draft.js
+++ b/src/views/plugin/workflow/api/draft.js
@@ -1,4 +1,4 @@
-import http from '@/http/api.js';
+import http from '@/axios';
 
 const prefix = '/blade-workflow/app/draft';
 

--- a/src/views/plugin/workflow/api/process.js
+++ b/src/views/plugin/workflow/api/process.js
@@ -1,4 +1,4 @@
-import http from '@/http/api.js';
+import http from '@/axios';
 
 const prefix = '/blade-workflow/app/process';
 

--- a/src/views/plugin/workflow/api/task.js
+++ b/src/views/plugin/workflow/api/task.js
@@ -1,4 +1,4 @@
-import http from '@/http/api.js';
+import http from '@/axios';
 
 const prefix = '/blade-workflow/app/task';
 

--- a/src/views/plugin/workflow/mixins/ex-form.js
+++ b/src/views/plugin/workflow/mixins/ex-form.js
@@ -10,6 +10,7 @@ import {
     addMultiInstance,
     withdrawTask,
 } from '../api/task.js';
+import { showToast } from 'vant';
 import { Base64 } from '@/utils/base64.js';
 import { useWorkflowStore } from '@/store/workflow.js';
 
@@ -226,10 +227,7 @@ export default {
                 }
 
                 if (!pass && !comment) {
-                    uni.showToast({
-                        title: '请填写批复意见',
-                        icon: 'none',
-                    });
+                    showToast({ message: '请填写批复意见' });
                     this.submitLoading = false;
                     reject();
                     return;
@@ -288,10 +286,7 @@ export default {
         // 人员选择弹窗
         handleUserSelect({ type, checkType }) {
             if (!this.comment && ['transfer', 'delegate'].includes(type)) {
-                uni.showToast({
-                    title: '请填写批复意见',
-                    icon: 'none',
-                });
+                showToast({ message: '请填写批复意见' });
                 return;
             }
             if (type == 'assignee') this.defaultChecked = this.$refs.examineForm.examineForm.assignee;
@@ -338,10 +333,7 @@ export default {
                 // 加签
                 this.submitLoading = true;
                 addMultiInstance(param).then(() => {
-                    uni.showToast({
-                        title: '加签成功',
-                        icon: 'none',
-                    });
+                    showToast({ message: '加签成功', type: 'success' });
                     this.submitLoading = false;
                 });
             } else if (type == 'copy') {
@@ -380,10 +372,7 @@ export default {
                 navigation.call(this.$router, location);
             };
             if (msg) {
-                uni.showToast({
-                    title: msg,
-                    icon: 'none',
-                });
+                showToast({ message: msg });
                 setTimeout(navigate, 1000);
             } else {
                 navigate();

--- a/src/views/plugin/workflow/pages/create/index.vue
+++ b/src/views/plugin/workflow/pages/create/index.vue
@@ -42,6 +42,8 @@
 import { defineComponent } from 'vue';
 import { list } from '../../api/process.js';
 import exForm from '../../mixins/ex-form.js';
+import { useUserStore } from '@/store/user.js';
+import { useAuthStore } from '@/store/auth.js';
 
 export default defineComponent({
     name: 'WorkflowCreatePage',
@@ -79,11 +81,18 @@ export default defineComponent({
             this.refreshToken(processDefinition);
         },
         refreshToken(processDefinition) {
-            const userInfo = uni.getStorageSync('loginInfo');
-            if (userInfo) {
-                this.$store.dispatch('refreshTokenFn', userInfo).finally(() => {
-                    this.dynamicRoute(processDefinition, 'start');
-                });
+            const userStore = useUserStore();
+            const authStore = useAuthStore();
+            const userInfo = userStore.userInfo;
+            if (userInfo && authStore.refreshToken) {
+                authStore
+                    .refresh()
+                    .catch((error) => {
+                        console.warn('[workflow] 刷新令牌失败', error);
+                    })
+                    .finally(() => {
+                        this.dynamicRoute(processDefinition, 'start');
+                    });
             } else {
                 this.dynamicRoute(processDefinition, 'start');
             }

--- a/src/views/plugin/workflow/pages/external/Leave/detail.vue
+++ b/src/views/plugin/workflow/pages/external/Leave/detail.vue
@@ -70,10 +70,10 @@
 <script>
 import { defineComponent } from 'vue';
 import { Base64 } from '@/utils/base64.js';
-import WkfFlow from '../../../components/wf-flow/index';
-import WkfUserSelect from '../../../components/wf-user-select/index';
-import WkfButton from '../../../components/wf-button/index';
-import WkfExamForm from '../../../components/wf-exam-form/index';
+import WkfFlow from '../../../components/wf-flow/index.vue';
+import WkfUserSelect from '../../../components/wf-user-select/index.vue';
+import WkfButton from '../../../components/wf-button/index.vue';
+import WkfExamForm from '../../../components/wf-exam-form/index.vue';
 import exForm from '../../../mixins/ex-form';
 
 export default defineComponent({

--- a/src/views/plugin/workflow/pages/external/Leave/detail.vue
+++ b/src/views/plugin/workflow/pages/external/Leave/detail.vue
@@ -69,6 +69,7 @@
 </template>
 <script>
 import { defineComponent } from 'vue';
+import { showToast } from 'vant';
 import { Base64 } from '@/utils/base64.js';
 import WkfFlow from '../../../components/wf-flow/index.vue';
 import WkfUserSelect from '../../../components/wf-user-select/index.vue';
@@ -242,9 +243,7 @@ export default defineComponent({
 
                     this.handleCompleteTask(pass, variables)
                         .then(() => {
-                            uni.showToast({
-                                title: '处理成功',
-                            });
+                            showToast({ message: '处理成功', type: 'success' });
                             setTimeout(() => {
                                 this.handleNavigateTo(
                                     {

--- a/src/views/plugin/workflow/pages/external/Leave/start.vue
+++ b/src/views/plugin/workflow/pages/external/Leave/start.vue
@@ -25,8 +25,8 @@
 <script>
 import { defineComponent } from 'vue';
 import { Base64 } from '@/utils/base64.js';
-import wkfUserSelect from '../../../components/wf-user-select/index';
-import wkfExamForm from '../../../components/wf-exam-form/index';
+import wkfUserSelect from '../../../components/wf-user-select/index.vue';
+import wkfExamForm from '../../../components/wf-exam-form/index.vue';
 import exForm from '../../../mixins/ex-form';
 
 export default defineComponent({

--- a/src/views/plugin/workflow/pages/form/detail.vue
+++ b/src/views/plugin/workflow/pages/form/detail.vue
@@ -106,6 +106,7 @@
 </template>
 <script>
 import { defineComponent } from 'vue';
+import { showToast } from 'vant';
 import { Base64 } from '@/utils/base64.js';
 import RendererComparePanel from '@/components/dc/renderer/RendererComparePanel.vue';
 import { isRendererTestEnvironment } from '@/utils/env';
@@ -116,6 +117,7 @@ import WkfButton from '../../components/wf-button/index.vue';
 import WkfExamForm from '../../components/wf-exam-form/index.vue';
 import exForm from '../../mixins/ex-form';
 import draft from '../../mixins/draft';
+import { useAuthStore } from '@/store/auth.js';
 
 export default defineComponent({
     name: 'WorkflowFormDetailPage',
@@ -169,10 +171,11 @@ export default defineComponent({
         },
         // 获取任务详情
         getDetail(taskId, processInsId) {
+            const authStore = useAuthStore();
             this.h5bpmn = {
                 taskId: taskId,
                 processInsId: processInsId,
-                token: uni.getStorageSync('accessToken'),
+                token: authStore.token,
             };
             this.getTaskDetail(taskId, processInsId).then((res) => {
                 const { process, form, flow } = res;
@@ -352,17 +355,15 @@ export default defineComponent({
 
                         this.handleCompleteTask(pass, variables)
                             .then(() => {
-                                uni.showToast({
-                                    title: '处理成功',
-                                });
-                                  setTimeout(() => {
-                                      this.handleNavigateTo({
-                                          name: 'WorkflowMine',
-                                          query: { current: '0' },
-                                          replace: true,
-                                      });
-                                      done();
-                                  }, 1000);
+                                showToast({ message: '处理成功', type: 'success' });
+                                setTimeout(() => {
+                                    this.handleNavigateTo({
+                                        name: 'WorkflowMine',
+                                        query: { current: '0' },
+                                        replace: true,
+                                    });
+                                    done();
+                                }, 1000);
                             })
                             .catch(() => {
                                 if (typeof done == 'function') done();
@@ -376,21 +377,15 @@ export default defineComponent({
             } else if (summaryForm) {
                 this.handleCompleteTask(pass, {})
                     .then(() => {
-                        uni.showToast({
-                            title: '处理成功',
-                        });
-                          setTimeout(() => {
-                              this.handleNavigateTo({ name: 'WorkflowMine', query: { current: '0' }, replace: true });
-                          }, 1000);
+                        showToast({ message: '处理成功', type: 'success' });
+                        setTimeout(() => {
+                            this.handleNavigateTo({ name: 'WorkflowMine', query: { current: '0' }, replace: true });
+                        }, 1000);
                     })
                     .catch(() => {
                         this.submitLoading = false;
                     });
-            } else
-                uni.showToast({
-                    title: '找不到需要提交的表单',
-                    icon: 'error',
-                });
+            } else showToast({ message: '找不到需要提交的表单', type: 'fail' });
         },
     },
 });

--- a/src/views/plugin/workflow/pages/form/start.vue
+++ b/src/views/plugin/workflow/pages/form/start.vue
@@ -83,8 +83,8 @@ import { defineComponent } from 'vue';
 import { Base64 } from '@/utils/base64.js';
 import RendererComparePanel from '@/components/dc/renderer/RendererComparePanel.vue';
 import { isRendererTestEnvironment } from '@/utils/env';
-import wkfUserSelect from '../../components/wf-user-select/index';
-import wkfExamForm from '../../components/wf-exam-form/index';
+import wkfUserSelect from '../../components/wf-user-select/index.vue';
+import wkfExamForm from '../../components/wf-exam-form/index.vue';
 import exForm from '../../mixins/ex-form';
 import draft from '../../mixins/draft';
 
@@ -135,12 +135,20 @@ export default defineComponent({
             this.getStartForm(processDefId).then((res) => {
                 let { form, appForm, startForm } = res;
                 if (form) {
-                    // #ifdef H5 || APP
-                    const option = { ...eval('(' + form + ')'), labelPosition: 'top' };
-                    // #endif
-                    // #ifdef MP
-                    const option = { ...JSON.parse(appForm), labelPosition: 'top' };
-                    // #endif
+                    let option;
+
+                    try {
+                        option = { ...eval('(' + form + ')'), labelPosition: 'top' };
+                    } catch (error) {
+                        try {
+                            option = { ...JSON.parse(appForm), labelPosition: 'top' };
+                        } catch (parseError) {
+                            console.error('[workflow] 无法解析流程表单配置', error, parseError);
+                            this.waiting = false;
+                            return;
+                        }
+                    }
+
                     const { column, group } = option;
 
                     const groupArr = [];

--- a/src/views/plugin/workflow/pages/mine/index.vue
+++ b/src/views/plugin/workflow/pages/mine/index.vue
@@ -44,7 +44,7 @@
 <script>
 import { defineComponent } from 'vue';
 import { todoList, doneList, myDoneList, sendList } from '../../api/process.js';
-import wkfCard from '../../components/wf-card/index';
+import wkfCard from '../../components/wf-card/index.vue';
 
 export default defineComponent({
     name: 'WorkflowMinePage',

--- a/src/views/plugin/workflow/pages/workbench/index.vue
+++ b/src/views/plugin/workflow/pages/workbench/index.vue
@@ -30,7 +30,7 @@
 
     <img
       class="creat"
-      src="@/static/images/tabbar/creact.png"
+      src="https://oss.nutflow.vip/rider/public/create.png"
       alt="发起流程"
       @click.stop="handleJump(girdList[1])"
     />
@@ -40,7 +40,7 @@
 import { defineComponent } from 'vue';
 import { mapState, mapActions } from 'pinia';
 import { useWorkflowStore } from '@/store/workflow.js';
-import wkfCard from '../../components/wf-card/index';
+import wkfCard from '../../components/wf-card/index.vue';
 
 export default defineComponent({
   name: 'WorkflowWorkbenchPage',


### PR DESCRIPTION
## Summary
- add missing workflow utilities for Base64 handling and form validation to unblock component imports
- introduce a RendererComparePanel wrapper that proxies to wf-form and guard workflow form parsing logic against malformed payloads
- correct workflow API/component imports and asset references so Vite can resolve runtime modules

## Testing
- npm run build *(fails: aborted after prolonged Sass deprecation spam)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915947814b083279a3ea121e160bfb6)