### PR TITLE
refactor: register wf-ui components with vue3 syntax

### DIFF
--- a/src/components/wf-ui/index.js
+++ b/src/components/wf-ui/index.js
@@ -8,11 +8,25 @@ const prototypes = {
   wfImage: 'https://oss.nutflow.vip/rider',
 };
 
+const componentModules = import.meta.glob('./components/**/*.vue', { eager: true });
+const components = Object.values(componentModules)
+  .map((module) => module?.default)
+  .filter((component) => component && (component.name || component.__name));
+
 export default {
-  install(appLike) {
-    const target = appLike.config?.globalProperties || appLike.prototype || {};
+  install(app) {
+    components.forEach((component) => {
+      const name = component.name || component.__name;
+      if (name) {
+        app.component(name, component);
+      }
+    });
+
+    const target = app.config?.globalProperties;
     Object.keys(prototypes).forEach((key) => {
-      target[key] = prototypes[key];
+      if (target) {
+        target[key] = prototypes[key];
+      }
       if (typeof uni !== 'undefined' && uni.$u) {
         uni.$u[key] = prototypes[key];
       }


### PR DESCRIPTION
## Summary
- register every wf-ui component with the Vue 3 `app.component` API during plugin install
- continue exposing wf-ui utility helpers on the application global properties and uni bridge

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a8aeab848327b6b9d10f295ac92c)