### PR TITLE
chore: forbid legacy Vue 2 setter APIs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,31 @@ export default [
         'error',
         { html: { void: 'always', normal: 'never', component: 'always' } },
       ],
+
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'this',
+          property: '$set',
+          message:
+            'Vue 3 移除了 this.$set，请直接给响应式对象赋值（例如：this[key] = value）。',
+        },
+        {
+          object: 'this',
+          property: '$delete',
+          message: 'Vue 3 移除了 this.$delete，请改用 delete 运算符。',
+        },
+        {
+          object: 'Vue',
+          property: 'set',
+          message: 'Vue 3 移除了 Vue.set，请直接修改响应式数据。',
+        },
+        {
+          object: 'Vue',
+          property: 'delete',
+          message: 'Vue 3 移除了 Vue.delete，请使用 delete 运算符。',
+        },
+      ],
     },
   },
 


### PR DESCRIPTION
## Summary
- add an ESLint restriction to prevent using Vue 2 setter helpers that no longer exist in Vue 3

## Testing
- npm run lint *(fails: existing lint violations in legacy workflow components and utilities)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c4b0277083279eccf293cb119cfc)