### PR TITLE
Persist login_info data in user store during account login

### DIFF
--- a/src/views/login/account.vue
+++ b/src/views/login/account.vue
@@ -154,12 +154,26 @@ async function onSubmit() {
     loading.value = true;
     await formRef.value?.validate?.();
 
-    await auth.loginByUsername({ ...formData });
+    const loginPayload = await auth.loginByUsername({ ...formData });
 
     try {
       await user.fetchUserInfo();
     } catch (e) {
       console.warn('[account-login] fetchUserInfo failed:', e);
+    }
+
+    const loginInfoCandidates = [
+      loginPayload?.login_info,
+      loginPayload?.loginInfo,
+      loginPayload?.data?.login_info,
+      loginPayload?.data?.loginInfo,
+    ];
+    const loginInfo = loginInfoCandidates.find((info) => info && typeof info === 'object');
+    if (loginInfo && typeof loginInfo === 'object') {
+      user.setUserInfo({
+        ...(user.userInfo || {}),
+        ...loginInfo,
+      });
     }
 
     if (remember.value) localStorage.setItem('LAST_USERNAME', formData.username);


### PR DESCRIPTION
## Summary
- capture the login response payload in the account login flow
- merge any login_info data from the payload into the Pinia user store so it is immediately available to consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184342cdbc8327b2c87586cd3d66d1)