### PR TITLE
feat: use local workflow assets

### DIFF
--- a/src/components/wf-ui/components/wf-empty/wf-empty.vue
+++ b/src/components/wf-ui/components/wf-empty/wf-empty.vue
@@ -9,6 +9,7 @@
 <script>
 import { defineComponent } from 'vue';
 import { Empty } from 'vant';
+import emptyIllustration from '@/views/plugin/workflow/static/images/public/empty.svg';
 
 export default defineComponent({
   name: 'WfEmpty',
@@ -24,8 +25,7 @@ export default defineComponent({
   },
   computed: {
     resolvedImage() {
-      const base = this.src || `${this.wfImage || ''}/public/empty.png`;
-      return base;
+      return this.src || emptyIllustration;
     },
     imageSizeStyle() {
       const size = typeof this.iconSize === 'number' ? `${this.iconSize}px` : this.iconSize;

--- a/src/components/wf-ui/index.js
+++ b/src/components/wf-ui/index.js
@@ -5,7 +5,6 @@ const prototypes = {
   validData,
   deepClone,
   findObject,
-  wfImage: 'https://oss.nutflow.vip/rider',
 };
 
 const componentModules = import.meta.glob('./components/**/*.vue', { eager: true });

--- a/src/views/plugin/workflow/pages/create/index.vue
+++ b/src/views/plugin/workflow/pages/create/index.vue
@@ -38,7 +38,7 @@
           >
             <img
               class="icon"
-              :src="processItem.icon || `${wfImage}/create/icon_${parseInt(cIndex % 10)}.png`"
+              :src="processItem.icon || createIcons[cIndex % createIcons.length]"
               alt="workflow icon"
             />
             <div class="flex-one r">
@@ -62,12 +62,16 @@ import exForm from '../../mixins/ex-form.js';
 import { useUserStore } from '@/store/user.js';
 import { useAuthStore } from '@/store/auth.js';
 
+const defaultCreateIcons = Array.from({ length: 10 }, (_, index) =>
+  new URL(`../../static/images/create/icon_${index}.svg`, import.meta.url).href,
+);
+
 export default defineComponent({
   name: 'WorkflowCreatePage',
   mixins: [exForm],
   data() {
     return {
-      wfImage: this.wfImage || 'https://oss.nutflow.vip/rider',
+      createIcons: defaultCreateIcons,
       searchValue: '',
       activeNames: [],
       list: [],

--- a/src/views/plugin/workflow/pages/mine/index.vue
+++ b/src/views/plugin/workflow/pages/mine/index.vue
@@ -242,7 +242,7 @@ export default defineComponent({
 .head-item {
   width: 100%;
   box-sizing: border-box;
-  background: url('https://oss.nutflow.vip/rider/mine/head_bg.png') no-repeat center bottom;
+  background: url('@/views/plugin/workflow/static/images/mine/head_bg.svg') no-repeat center bottom;
   background-size: 100% 100%;
 }
 

--- a/src/views/plugin/workflow/pages/workbench/index.vue
+++ b/src/views/plugin/workflow/pages/workbench/index.vue
@@ -15,7 +15,7 @@
             class="item"
             @click="handleJump(item)"
           >
-            <img :src="`${wfImage}/home/icon_${item.type}.png`" class="icon" alt="" />
+            <img :src="homeIcons[item.type] || homeIconFallback" class="icon" alt="" />
             <div class="name">{{ item.name }}</div>
           </div>
         </div>
@@ -64,12 +64,22 @@ import { mapState, mapActions } from 'pinia';
 import { useWorkflowStore } from '@/store/workflow.js';
 import wkfCard from '../../components/wf-card/index.vue';
 
+const homeIconMap = {
+  db: new URL('../../static/images/home/icon_db.svg', import.meta.url).href,
+  qq: new URL('../../static/images/home/icon_qq.svg', import.meta.url).href,
+  yb: new URL('../../static/images/home/icon_yb.svg', import.meta.url).href,
+  bj: new URL('../../static/images/home/icon_bj.svg', import.meta.url).href,
+};
+
+const homeIconFallback = homeIconMap.db;
+
 export default defineComponent({
   name: 'WorkflowWorkbenchPage',
   components: { wkfCard },
   data() {
     return {
-      wfImage: this.wfImage || 'https://oss.nutflow.vip/rider',
+      homeIcons: homeIconMap,
+      homeIconFallback,
       create: {
         location: { name: 'WorkflowCreate' },
       },
@@ -191,7 +201,7 @@ page {
 .head-item {
   position: relative;
   padding: 28px 18px 72px;
-  background: url('https://oss.nutflow.vip/rider/home/head_bg.png') no-repeat;
+  background: url('@/views/plugin/workflow/static/images/home/head_bg.svg') no-repeat;
   background-size: 100% 100%;
   color: #ffffff;
 

--- a/src/views/plugin/workflow/static/images/create/icon_0.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_0.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient0" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a77ff" />
+      <stop offset="100%" stop-color="#7aa0ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient0)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">0</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_1.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_1.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#924dff" />
+      <stop offset="100%" stop-color="#b97dff" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient1)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">1</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_2.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_2.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient2" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00b894" />
+      <stop offset="100%" stop-color="#4dd6b9" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient2)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">2</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_3.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_3.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient3" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff7b59" />
+      <stop offset="100%" stop-color="#ffb18c" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient3)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">3</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_4.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_4.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient4" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff5f96" />
+      <stop offset="100%" stop-color="#ff9fc4" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient4)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">4</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_5.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_5.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient5" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffa534" />
+      <stop offset="100%" stop-color="#ffd28a" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient5)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">5</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_6.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_6.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient6" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#09bcd3" />
+      <stop offset="100%" stop-color="#63def0" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient6)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">6</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_7.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_7.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient7" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#546de5" />
+      <stop offset="100%" stop-color="#95a7ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient7)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">7</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_8.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_8.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient8" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#3dc1d3" />
+      <stop offset="100%" stop-color="#78e0e9" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient8)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">8</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/create/icon_9.svg
+++ b/src/views/plugin/workflow/static/images/create/icon_9.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="createGradient9" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f0932b" />
+      <stop offset="100%" stop-color="#ffd082" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#createGradient9)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">9</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/home/head_bg.svg
+++ b/src/views/plugin/workflow/static/images/home/head_bg.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="750" height="260" viewBox="0 0 750 260">
+  <defs>
+    <linearGradient id="homeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4668ff" />
+      <stop offset="50%" stop-color="#6f8bff" />
+      <stop offset="100%" stop-color="#a5b9ff" />
+    </linearGradient>
+  </defs>
+  <rect width="750" height="260" rx="24" fill="url(#homeGradient)" />
+  <circle cx="100" cy="70" r="40" fill="rgba(255,255,255,0.18)" />
+  <circle cx="680" cy="50" r="55" fill="rgba(255,255,255,0.12)" />
+  <circle cx="610" cy="190" r="70" fill="rgba(255,255,255,0.18)" />
+  <circle cx="180" cy="200" r="55" fill="rgba(255,255,255,0.15)" />
+</svg>

--- a/src/views/plugin/workflow/static/images/home/icon_bj.svg
+++ b/src/views/plugin/workflow/static/images/home/icon_bj.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="bjGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff7b59" />
+      <stop offset="100%" stop-color="#ffb18c" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#bjGradient)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">结</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/home/icon_db.svg
+++ b/src/views/plugin/workflow/static/images/home/icon_db.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="dbGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4a77ff" />
+      <stop offset="100%" stop-color="#7aa0ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#dbGradient)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">待</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/home/icon_qq.svg
+++ b/src/views/plugin/workflow/static/images/home/icon_qq.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="qqGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#924dff" />
+      <stop offset="100%" stop-color="#b97dff" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#qqGradient)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">请</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/home/icon_yb.svg
+++ b/src/views/plugin/workflow/static/images/home/icon_yb.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <defs>
+    <linearGradient id="ybGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00b894" />
+      <stop offset="100%" stop-color="#4dd6b9" />
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="40" r="38" fill="url(#ybGradient)" />
+  <text x="40" y="52" font-size="32" font-family="'PingFang SC', 'Microsoft YaHei', Arial" fill="#ffffff" text-anchor="middle">办</text>
+</svg>

--- a/src/views/plugin/workflow/static/images/mine/head_bg.svg
+++ b/src/views/plugin/workflow/static/images/mine/head_bg.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="750" height="280" viewBox="0 0 750 280">
+  <defs>
+    <linearGradient id="mineGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff9c5b" />
+      <stop offset="50%" stop-color="#ffb979" />
+      <stop offset="100%" stop-color="#ffd6a8" />
+    </linearGradient>
+  </defs>
+  <rect width="750" height="280" rx="24" fill="url(#mineGradient)" />
+  <circle cx="120" cy="80" r="50" fill="rgba(255,255,255,0.25)" />
+  <circle cx="640" cy="70" r="60" fill="rgba(255,255,255,0.16)" />
+  <circle cx="620" cy="210" r="80" fill="rgba(255,255,255,0.18)" />
+  <circle cx="200" cy="220" r="65" fill="rgba(255,255,255,0.2)" />
+</svg>

--- a/src/views/plugin/workflow/static/images/public/empty.svg
+++ b/src/views/plugin/workflow/static/images/public/empty.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="200" viewBox="0 0 240 200">
+  <defs>
+    <linearGradient id="emptyGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#dfe7ff" />
+      <stop offset="100%" stop-color="#f7f8ff" />
+    </linearGradient>
+  </defs>
+  <rect x="20" y="40" width="200" height="120" rx="18" fill="url(#emptyGradient)" />
+  <rect x="40" y="60" width="160" height="12" rx="6" fill="#c2cdf5" />
+  <rect x="40" y="84" width="140" height="12" rx="6" fill="#cfd8fb" />
+  <rect x="40" y="108" width="120" height="12" rx="6" fill="#dfe6ff" />
+  <circle cx="60" cy="140" r="10" fill="#c2cdf5" />
+  <circle cx="90" cy="140" r="10" fill="#cfd8fb" />
+  <circle cx="120" cy="140" r="10" fill="#e5ecff" />
+  <text x="120" y="185" text-anchor="middle" font-size="16" fill="#9aa5d6" font-family="'PingFang SC', 'Microsoft YaHei', Arial">暂无数据</text>
+</svg>


### PR DESCRIPTION
## Summary
- add local SVG assets for the workflow plugin (home/mine backgrounds, workbench grid icons, create defaults and empty state)
- update the workbench, create and mine pages to consume the new static assets instead of oss.nutflow URLs
- switch the wf-empty component to the local illustration and drop the unused wfImage prototype reference

## Testing
- npm test *(fails: vitest cannot resolve @/router inside src/utils/http.js in the existing suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8840fef48327b46748367aa159d8)