### PR TITLE
feat: add vant pc workflow components

### DIFF
--- a/src/components/dc-ui/constant/cacheData.js
+++ b/src/components/dc-ui/constant/cacheData.js
@@ -1580,6 +1580,45 @@ export default {
       },
     ],
   },
+  laborRegister: {
+    url: '/blade-bip/laborRegister/select-data',
+    defaultLabel: 'name',
+    defaultLabelName: '劳务人员',
+    title: '劳务人员',
+    placeholder: '请输入人员姓名查询',
+    submitTitle: '选择',
+    dialogGet: (params) => {
+      return request({
+        url: '/blade-bip/laborRegister/list-select',
+        method: 'get',
+        params,
+      });
+    },
+    column: [
+      { label: '人员姓名', prop: 'name', search: true, searchProps: { is: 'input' } },
+      {
+        label: '劳务公司',
+        prop: 'companyId',
+        component: 'dc-view',
+        objectName: 'company',
+      },
+      {
+        label: '部门',
+        prop: 'deptId',
+        component: 'dc-view',
+        objectName: 'dept',
+      },
+      { label: '岗位等级', prop: 'positionDictCode' },
+      { label: '岗位', prop: 'jobGradeDict' },
+      {
+        label: '直属上级',
+        prop: 'leaderId',
+        component: 'dc-view',
+        objectName: 'user',
+      },
+      { label: '入职时间', prop: 'joinedDate' },
+    ],
+  },
   pdpCustomerArea: {
     url: '/blade-bip/CrmCustomerArea/select-data',
     defaultLabel: 'areaName',

--- a/src/views/plugin/workflow/components-pc-ele/base/SelectionField.vue
+++ b/src/views/plugin/workflow/components-pc-ele/base/SelectionField.vue
@@ -1,0 +1,91 @@
+<template>
+  <SelectDialog
+    v-model="innerValue"
+    :object-name="objectName"
+    :placeholder="placeholder"
+    :label="label"
+    :disabled="disabled"
+    :clearable="clearable"
+    :multiple="isMultiple"
+    :width="width"
+    :query="query"
+    :show-value="showValue"
+    :return-type="computedReturnType"
+    :master-key="masterKey"
+    :show-key="showKey"
+    :tag-color="tagColor"
+    :tag-text-color="tagTextColor"
+    :change="handleDialogChange"
+    v-bind="restAttrs"
+  />
+</template>
+
+<script setup>
+import { computed, reactive, ref, useAttrs, watch } from 'vue';
+import SelectDialog from '@/components/dc-ui/components/SelectDialog/index.vue';
+
+defineOptions({ name: 'NfSelectionField', inheritAttrs: false });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  objectName: { type: String, required: true },
+  placeholder: { type: String, default: '' },
+  label: { type: String, default: '' },
+  disabled: { type: Boolean, default: false },
+  clearable: { type: Boolean, default: true },
+  multiple: { type: Boolean, default: false },
+  checkType: { type: String, default: 'radio' },
+  width: { type: String, default: '100%' },
+  query: { type: Object, default: () => ({}) },
+  showValue: { type: Boolean, default: true },
+  returnType: { type: String, default: '' },
+  masterKey: { type: String, default: '' },
+  showKey: { type: String, default: '' },
+  tagColor: { type: String, default: '#ecf5ff' },
+  tagTextColor: { type: String, default: '#1989fa' },
+  change: { type: Function, default: null },
+});
+
+const emit = defineEmits(['update:modelValue', 'change']);
+const attrs = useAttrs();
+
+const innerValue = ref(props.modelValue);
+const restAttrs = reactive({});
+
+const isMultiple = computed(() => props.multiple || props.checkType === 'checkbox');
+const computedReturnType = computed(() => {
+  if (props.returnType) return props.returnType;
+  return isMultiple.value ? 'array' : 'single';
+});
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => {
+    emit('update:modelValue', val);
+  },
+  { deep: true }
+);
+
+function handleDialogChange(payload) {
+  const value = payload?.value ?? payload;
+  emit('change', value);
+  props.change?.(payload);
+}
+
+watch(
+  () => ({ ...attrs }),
+  (val) => {
+    Object.keys(restAttrs).forEach((key) => delete restAttrs[key]);
+    Object.assign(restAttrs, val);
+  },
+  { immediate: true }
+);
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-button.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-button.vue
@@ -1,0 +1,23 @@
+<template>
+  <WfButton v-bind="passthrough" />
+</template>
+
+<script setup>
+import { computed, useAttrs } from 'vue';
+import WfButton from '../components/wf-button/index.vue';
+
+defineOptions({ name: 'NfButton', inheritAttrs: false });
+
+const props = defineProps({
+  loading: { type: Boolean, default: false },
+  buttonList: { type: Array, default: () => [] },
+  process: { type: Object, default: () => ({}) },
+  comment: { type: String, default: '' },
+});
+
+const attrs = useAttrs();
+const passthrough = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-category.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-category.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="nf-category">
+    <van-search v-model="filterText" placeholder="搜索分类" background="#f7f8fa" />
+    <div class="nf-category__tree">
+      <TreeNodes :nodes="filteredTree" @node-click="handleNodeClick" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { Toast } from 'vant';
+import TreeNodes from './nf-category/TreeNodes.vue';
+import { tree } from '../api/design/category.js';
+
+defineOptions({ name: 'NfCategory' });
+
+const emit = defineEmits(['node-click', 'list-change']);
+const filterText = ref('');
+const sourceTree = ref([]);
+
+const filteredTree = computed(() => {
+  const keyword = filterText.value.trim().toLowerCase();
+  if (!keyword) return sourceTree.value;
+  const filterNodes = (nodes) => {
+    if (!Array.isArray(nodes)) return [];
+    return nodes
+      .map((node) => {
+        const children = filterNodes(node.children || []);
+        const hit = (node.name || '').toLowerCase().includes(keyword);
+        if (hit || children.length) {
+          return { ...node, children };
+        }
+        return null;
+      })
+      .filter(Boolean);
+  };
+  return filterNodes(sourceTree.value);
+});
+
+async function loadTree() {
+  try {
+    const res = await tree();
+    const list = res?.data?.data || [];
+    sourceTree.value = [{ id: '', name: '全部' }, ...list];
+    emit('list-change', JSON.parse(JSON.stringify(list)));
+  } catch (error) {
+    Toast.fail('分类加载失败');
+  }
+}
+
+function handleNodeClick(node) {
+  emit('node-click', { id: node.id });
+}
+
+onMounted(loadTree);
+</script>
+
+<style scoped>
+.nf-category {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nf-category__tree {
+  max-height: 60vh;
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 8px;
+}
+</style>

--- a/src/views/plugin/workflow/components-pc-ele/nf-category/TreeNodes.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-category/TreeNodes.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="tree-nodes">
+    <div v-for="node in nodes" :key="node.id" class="tree-node">
+      <van-cell :title="node.name" is-link @click="emit('node-click', node)" />
+      <div v-if="node.children && node.children.length" class="tree-node__children">
+        <TreeNodes :nodes="node.children" @node-click="emit('node-click', $event)" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: 'TreeNodes' });
+
+defineProps({
+  nodes: { type: Array, default: () => [] },
+});
+const emit = defineEmits(['node-click']);
+</script>
+
+<style scoped>
+.tree-node__children {
+  padding-left: 12px;
+}
+</style>

--- a/src/views/plugin/workflow/components-pc-ele/nf-dept-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-dept-select.vue
@@ -1,0 +1,46 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="dept"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfDeptSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择部门' },
+  label: { type: String, default: '部门' },
+});
+
+const emit = defineEmits(['update:modelValue', 'confirm']);
+const innerValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('confirm', val);
+}
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-exam-form.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-exam-form.vue
@@ -1,0 +1,21 @@
+<template>
+  <WfExamForm v-bind="passthrough" />
+</template>
+
+<script setup>
+import { computed, useAttrs } from 'vue';
+import WfExamForm from '../components/wf-exam-form/index.vue';
+
+defineOptions({ name: 'NfExamForm', inheritAttrs: false });
+
+const props = defineProps({
+  process: { type: Object, default: () => ({}) },
+  comment: { type: String, default: '' },
+});
+
+const attrs = useAttrs();
+const passthrough = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-flow.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-flow.vue
@@ -1,0 +1,20 @@
+<template>
+  <WfFlow v-bind="passthrough" />
+</template>
+
+<script setup>
+import { computed, useAttrs } from 'vue';
+import WfFlow from '../components/wf-flow/index.vue';
+
+defineOptions({ name: 'NfFlow', inheritAttrs: false });
+
+const props = defineProps({
+  flow: { type: Array, default: () => [] },
+});
+
+const attrs = useAttrs();
+const passthrough = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-plan-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-plan-select.vue
@@ -1,0 +1,49 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="mmrPlanOrder"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :query="query"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfPlanSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择现场计划单' },
+  label: { type: String, default: '现场计划' },
+  defaultQuery: { type: Object, default: () => ({ planOrderStatus: 'DC_MMR_PLAN_ORDER_STATUS_IP' }) },
+});
+
+const emit = defineEmits(['update:modelValue', 'onConfirm']);
+const innerValue = ref(props.modelValue);
+const query = computed(() => ({ ...props.defaultQuery }));
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('onConfirm', val);
+}
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-prdmo-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-prdmo-select.vue
@@ -1,0 +1,46 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="workList"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfPrdmoSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择生产订单' },
+  label: { type: String, default: '生产订单' },
+});
+
+const emit = defineEmits(['update:modelValue', 'onConfirm']);
+const innerValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('onConfirm', val);
+}
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-radio-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-radio-select.vue
@@ -1,0 +1,21 @@
+<template>
+  <NfUserSelect v-bind="passthrough" check-type="radio" />
+</template>
+
+<script setup>
+import { computed, useAttrs } from 'vue';
+import NfUserSelect from './nf-user-select.vue';
+
+defineOptions({ name: 'NfRadioSelect', inheritAttrs: false });
+
+const props = defineProps({
+  defaultChecked: { type: String, default: '' },
+  userUrl: { type: String, default: '/blade-system/search/user' },
+});
+
+const attrs = useAttrs();
+const passthrough = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-user-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-user-select.vue
@@ -1,0 +1,22 @@
+<template>
+  <WfUserSelect v-bind="passthrough" />
+</template>
+
+<script setup>
+import { computed, useAttrs } from 'vue';
+import WfUserSelect from '../components/wf-user-select/index.vue';
+
+defineOptions({ name: 'NfUserSelect', inheritAttrs: false });
+
+const props = defineProps({
+  defaultChecked: { type: String, default: '' },
+  userUrl: { type: String, default: '/blade-system/search/user' },
+  checkType: { type: String, default: 'radio' },
+});
+
+const attrs = useAttrs();
+const passthrough = computed(() => ({
+  ...props,
+  ...attrs,
+}));
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-vo-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-vo-select.vue
@@ -1,0 +1,46 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="pdpProject"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfVoSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择项目' },
+  label: { type: String, default: '项目' },
+});
+
+const emit = defineEmits(['update:modelValue', 'onConfirm']);
+const innerValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('onConfirm', val);
+}
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-withdrawn-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-withdrawn-select.vue
@@ -1,0 +1,46 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="laborRegister"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfWithdrawnSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择劳务人员' },
+  label: { type: String, default: '劳务人员' },
+});
+
+const emit = defineEmits(['update:modelValue', 'onConfirm']);
+const innerValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('onConfirm', val);
+}
+</script>

--- a/src/views/plugin/workflow/components-pc-ele/nf-wl-select.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-wl-select.vue
@@ -1,0 +1,46 @@
+<template>
+  <SelectionField
+    v-model="innerValue"
+    object-name="stockMaterialList"
+    :placeholder="placeholder"
+    :label="label"
+    :check-type="checkType"
+    :return-type="checkType === 'radio' ? 'single' : 'array'"
+    @change="handleChange"
+  />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import SelectionField from './base/SelectionField.vue';
+
+defineOptions({ name: 'NfWlSelect' });
+
+const props = defineProps({
+  modelValue: { type: [String, Number, Array, Object], default: null },
+  checkType: { type: String, default: 'radio' },
+  placeholder: { type: String, default: '请选择物料' },
+  label: { type: String, default: '物料' },
+});
+
+const emit = defineEmits(['update:modelValue', 'onConfirm']);
+const innerValue = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val;
+  },
+  { deep: true }
+);
+
+watch(
+  innerValue,
+  (val) => emit('update:modelValue', val),
+  { deep: true }
+);
+
+function handleChange(val) {
+  emit('onConfirm', val);
+}
+</script>


### PR DESCRIPTION
## Summary
- add a reusable SelectionField wrapper around the dc SelectDialog component for desktop workflow pickers
- port the nf-* workflow widgets to Vue 3 + Vant 4, reusing the existing wf-* implementations where possible and wiring up plan/material selectors via SelectionField
- register a new laborRegister data source inside cacheData so the withdrawn selector can call the correct API

## Testing
- `npm run lint` *(fails: repository already contains hundreds of lint errors unrelated to these changes)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c10ba06ec8327aad2011bf0bc196b)