### PR TITLE
refactor: rebuild wf-prdmo-select with Vant 4

### DIFF
--- a/src/views/plugin/workflow/components-pc-ele/custom-fields/wf-prdmo-select/index.vue
+++ b/src/views/plugin/workflow/components-pc-ele/custom-fields/wf-prdmo-select/index.vue
@@ -1,101 +1,92 @@
 <template>
   <div class="wl-wrapper">
-    <el-input
+    <van-field
       v-model="name"
-      :size="size"
-      suffix-icon="el-icon-search"
-      :placeholder="placeholder || '专案物料查询'"
+      class="wl-field"
       readonly
+      clickable
+      is-link
+      :size="size"
+      :placeholder="placeholder || '专案物料查询'"
       :disabled="disabled"
+      :right-icon="disabled || readonly ? '' : 'search'"
       @click="handleSelect"
-    ></el-input>
-    <!-- 选择弹窗 -->
-    <nf-Prdmo-select
-      ref="prdmo-select"
+    />
+    <nf-prdmo-select
+      ref="prdmoSelectRef"
       :check-type="checkType"
       :default-checked="modelValue"
-      checkType="radio"
       @onConfirm="handleSelectConfirm"
-    ></nf-Prdmo-select>
+    />
   </div>
 </template>
-<script>
+
+<script setup>
+import { ref, watch } from 'vue';
 import NfPrdmoSelect from '../../nf-prdmo-select/index.vue';
 
-export default {
-  name: 'prdmo-select',
-  components: { NfPrdmoSelect },
-  emits: ['update:modelValue'],
-  props: {
-    modelValue: [String, Number, Object],
-    checkType: {
-      // radio单选 checkbox多选
-      type: String,
-      default: () => {
-        return 'radio';
-      },
-    },
-    size: {
-      type: String,
-      default: () => {
-        return 'default';
-      },
-    },
-    readonly: {
-      type: Boolean,
-      default: false,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    placeholder: String,
-    change: Function,
-  },
+defineOptions({ name: 'prdmo-select' });
 
-  data() {
-    return {
-      name: '',
-    };
+const props = defineProps({
+  modelValue: { type: [String, Number, Object], default: '' },
+  checkType: {
+    type: String,
+    default: () => 'radio',
   },
+  size: {
+    type: String,
+    default: () => 'default',
+  },
+  readonly: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  placeholder: { type: String, default: '' },
+  change: Function,
+});
 
-  watch: {
-    modelValue: {
-      handler(val) {
-        if (val) {
-          this.name = this.modelValue.materialName;
-        } else this.name = '';
-      },
-      immediate: true,
-    },
-  },
+const emit = defineEmits(['update:modelValue']);
+const name = ref('');
+const prdmoSelectRef = ref();
 
-  methods: {
-    handleSelect() {
-      if (this.readonly || this.disabled) return;
-      this.$refs['prdmo-select'].visible = true;
-    },
-    handleSelectConfirm(list) {
-      this.name = list[0].materialName;
-      this.$emit('update:modelValue', list[0]);
-      if (this.change && typeof this.change == 'function') this.change({ value: list[0] });
-      //  用于表单数据回显change事件
-      //   Object.getOwnPropertyNames(value).forEach(item => {
-      //     console.log(item, '-----------', value[item]);
-      //     if (this.form.hasOwnProperty(item)) {
-      //       this.form[item] = value[item];
-      //     }
-      //   });
-    },
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (val && typeof val === 'object') {
+      name.value = val.materialName || '';
+    } else {
+      name.value = '';
+    }
   },
-};
+  { immediate: true, deep: true }
+);
+
+function handleSelect() {
+  if (props.readonly || props.disabled) return;
+  if (prdmoSelectRef.value?.open) {
+    prdmoSelectRef.value.open();
+  } else if (prdmoSelectRef.value) {
+    prdmoSelectRef.value.visible = true;
+  }
+}
+
+function handleSelectConfirm(list = []) {
+  const first = list[0];
+  if (!first) return;
+  name.value = first.materialName || '';
+  emit('update:modelValue', first);
+  if (typeof props.change === 'function') {
+    props.change({ value: first });
+  }
+}
 </script>
-<style lang="scss" scoped>
+
+<style scoped lang="scss">
 .wl-wrapper {
   display: flex;
-  align-items: center;
-  .organization {
-    margin-right: 20px;
-  }
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wl-field {
+  --van-field-input-text-color: var(--van-text-color);
 }
 </style>

--- a/src/views/plugin/workflow/components-pc-ele/nf-prdmo-select/index.vue
+++ b/src/views/plugin/workflow/components-pc-ele/nf-prdmo-select/index.vue
@@ -1,292 +1,354 @@
 <template>
-  <el-dialog
-    ref="nf-dialog"
+  <van-popup
+    v-model:show="visible"
     class="nf-dialog"
-    v-model="visible"
-    title="专案物料查询"
-    width="60%"
-    :before-close="handleClose"
-    append-to-body
+    position="center"
+    round
+    closeable
+    close-icon="cross"
+    close-icon-position="top-right"
+    :close-on-click-overlay="true"
+    @close="handleClose"
   >
-    <nf-crud
-      v-if="isInit && visible"
-      :option="option"
-      :table-loading="loading"
-      :data="data"
-      v-model:page="page"
-      v-model="form"
-      ref="crud"
-      @search-change="searchChange"
-      @search-reset="searchReset"
-      @selection-change="selectionList = $event"
-      @current-change="page.current = $event"
-      @size-change="page.pageSize = $event"
-      @row-click="rowClick"
-      @on-load="onLoad"
-    >
-      <template v-if="checkType == 'radio'" #radio="{ row }">
-        <el-radio v-model="form.radio" :label="row.id"><i></i></el-radio>
-      </template>
-    </nf-crud>
-    <template #footer>
-      <span class="dialog-footer">
-        <el-button @click="handleClose" size="default">取 消</el-button>
-        <el-button type="primary" @click="handleConfirm" size="default">确 定</el-button>
-      </span>
-    </template>
-  </el-dialog>
+    <div class="nf-dialog__container">
+      <header class="nf-dialog__header">
+        <span class="nf-dialog__title">专案物料查询</span>
+      </header>
+      <section class="nf-dialog__body">
+        <van-radio-group v-model="form.radio">
+          <nf-crud
+            v-if="isInit && visible"
+            ref="crudRef"
+            :option="option"
+            :props="tableProps"
+            :table-loading="loading"
+            :data="data"
+            v-model:page="page"
+            v-model="form"
+            @search-change="searchChange"
+            @search-reset="searchReset"
+            @selection-change="onSelectionChange"
+            @current-change="onCurrentChange"
+            @size-change="onSizeChange"
+            @row-click="rowClick"
+            @on-load="onLoad"
+          >
+            <template v-if="checkType === 'radio'" #radio="{ row }">
+              <van-radio :name="row.id" icon-size="16">
+                <template #icon="{ checked }">
+                  <span class="nf-radio-icon" :class="{ 'nf-radio-icon--checked': checked }"></span>
+                </template>
+              </van-radio>
+            </template>
+          </nf-crud>
+        </van-radio-group>
+      </section>
+      <footer class="nf-dialog__footer">
+        <van-button size="small" @click="handleClose">取 消</van-button>
+        <van-button type="primary" size="small" @click="handleConfirm">确 定</van-button>
+      </footer>
+    </div>
+  </van-popup>
 </template>
-<script>
+
+<script setup>
+import { computed, defineEmits, defineProps, defineExpose, onMounted, reactive, ref, watch, nextTick } from 'vue';
+import { showToast } from 'vant';
+import request from '@/utils/http';
+import { findObject } from '@/components/wf-ui/util/index.js';
 import { getMaterialDetail } from '@/api/system/user';
 
-export default {
-  props: {
-    modelValue: [String, Number, Object],
-    voUrl: {
-      type: String,
-      default: () => {
-        return '/blade-erp/v-prd-mo-material/list';
-      },
-    },
-    customOption: Object,
-    checkType: {
-      type: String,
-      default: () => {
-        return 'radio';
-      },
-    },
-    fuseorgid: {
-      type: String,
-      default: () => {
-        return '';
-      },
-    },
-  },
-  watch: {
-    checkType: {
-      handler(val) {
-        if (val == 'radio') {
-          this.option.selection = false;
-          this.findObject(this.option.column, 'radio').hide = false;
-        } else {
-          this.option.selection = true;
-          this.findObject(this.option.column, 'radio').hide = true;
-        }
-      },
-      immediate: true,
-    },
-  },
-  computed: {
-    ids() {
-      let ids = new Set();
-      this.selectionList.forEach(ele => {
-        ids.add(ele.id);
-      });
-      return Array.from(ids).join(',');
-    },
-    names() {
-      let names = new Set();
-      this.selectionList.forEach(ele => {
-        names.add(ele.realName);
-      });
-      return Array.from(names).join(',');
-    },
-  },
-  data() {
-    return {
-      isInit: false,
-      visible: false,
-      form: {},
-      query: {},
-      loading: false,
-      page: {
-        size: 10,
-        current: 1,
-        total: 0,
-      },
-      selectionList: [],
-      data: [],
-      props: {
-        id: 'id',
-        name: 'realName',
-        records: 'data.data.records',
-        total: 'data.data.total',
-      },
-      option: {
-        size: 'default',
-        searchSize: 'default',
-        align: 'center',
-        menu: false,
-        addBtn: false,
-        header: false,
-        border: true,
-        tip: false,
-        reserveSelection: true,
-        highlightCurrentRow: true,
-        gutter: 5,
-        searchMenuSpan: 6,
-        selection: true,
-        column: [
-          {
-            label: '',
-            prop: 'radio',
-            type: 'radio',
-            width: 55,
-            hide: true,
-          },
-          {
-            label: '计划跟踪号',
-            prop: 'motno',
-            overHidden: true,
-            search: true,
-          },
-          {
-            label: '物料编码',
-            prop: 'materialCode',
-            overHidden: true,
-            width: 90,
-            search: true,
-          },
+defineOptions({ name: 'nf-prdmo-select' });
 
-          {
-            label: '物料名称',
-            prop: 'materialName',
-            overHidden: true,
-            search: true,
-          },
-          {
-            label: '规格型号',
-            prop: 'specification',
-            overHidden: true,
-          },
-          {
-            label: '数量',
-            prop: 'qty',
-            overHidden: true,
-          },
-        ],
-      },
-    };
+const props = defineProps({
+  modelValue: { type: [String, Number, Object], default: '' },
+  defaultChecked: { type: [String, Number, Object], default: '' },
+  voUrl: {
+    type: String,
+    default: () => '/blade-erp/v-prd-mo-material/list',
   },
-  mounted() {
-    this.init();
+  customOption: { type: Object, default: null },
+  checkType: {
+    type: String,
+    default: () => 'radio',
   },
-  methods: {
-    init() {
-      if (!this.isInit) {
-        if (this.customOption) {
-          const { column, userProps } = this.customOption;
-          if (column) this.option.column = column;
-          if (userProps) this.props = userProps;
-        }
-        this.isInit = true;
-      }
-    },
-    handleConfirm() {
-      if (this.selectionList.length === 0) {
-        this.$message.warning('请选择至少一条数据');
-        return;
-      }
-      this.$emit('onConfirm', this.selectionList);
-      this.handleClose();
-    },
-    handleClose(done) {
-      // this.selectionClear()
-      this.visible = false;
-      if (done && typeof done == 'function') done();
-    },
-    searchReset() {
-      this.query = {};
-      this.onLoad(this.page);
-    },
-    searchChange(params, done) {
-      this.query = params;
-      this.page.current = 1;
-      this.onLoad(this.page, params);
-      done();
-    },
-    selectionClear() {
-      this.selectionList = [];
-      if (this.$refs.crud) this.$refs.crud.toggleSelection();
-    },
-    rowClick(row) {
-      if (this.checkType == 'radio') {
-        this.selectionList = [row];
-        this.form.radio = row.id;
-      } else this.$refs.crud.toggleSelection([row]);
-    },
-    async changeDefaultChecked() {
-      if (!this.defaultChecked) return;
-      let defaultChecked = this.defaultChecked;
-      if (this.checkType == 'checkbox') {
-        // this.selectionClear()
-        const checks = defaultChecked.split(',');
-        if (checks.length > 0) {
-          setTimeout(() => {
-            checks.forEach(async c => {
-              let row = this.data.find(d => d.id == c); // 当前页查找
-              if (!row) {
-                row = this.selectionList.find(d => d.id == c); // 勾选列表查找
-                if (!row) {
-                  let res = await getMaterialDetail(c); // 接口查找
-                  if (res.data.data) row = res.data.data;
-                }
-              }
-              if (row && this.$refs.crud) this.$refs.crud.toggleRowSelection(row, true);
-            });
-          }, 500);
-        }
-      } else {
-        let row = this.data.find(d => d.id == defaultChecked.id);
+  fuseorgid: {
+    type: String,
+    default: () => '',
+  },
+});
 
-        if (!row) {
-          let res = await getMaterialDetail({
-            materialCode: defaultChecked.id,
-          });
-          if (res.data.data) row = res.data.data;
-        }
+const emit = defineEmits(['onConfirm']);
 
-        if (row) {
-          this.selectionList = [row];
-          this.form.radio = defaultChecked.id;
-        } else {
-          this.selectionList = [];
-          this.form.radio = '';
+const visible = ref(false);
+const isInit = ref(false);
+const loading = ref(false);
+const form = ref({ radio: '' });
+const page = ref({ size: 10, current: 1, total: 0, pageSize: 10 });
+const query = ref({});
+const data = ref([]);
+const selectionList = ref([]);
+const crudRef = ref();
+
+const tableProps = reactive({
+  id: 'id',
+  name: 'realName',
+  records: 'data.data.records',
+  total: 'data.data.total',
+});
+
+const option = reactive({
+  size: 'default',
+  searchSize: 'default',
+  align: 'center',
+  menu: false,
+  addBtn: false,
+  header: false,
+  border: true,
+  tip: false,
+  reserveSelection: true,
+  highlightCurrentRow: true,
+  gutter: 5,
+  searchMenuSpan: 6,
+  selection: true,
+  column: [
+    { label: '', prop: 'radio', type: 'radio', width: 55, hide: true },
+    { label: '计划跟踪号', prop: 'motno', overHidden: true, search: true },
+    { label: '物料编码', prop: 'materialCode', overHidden: true, width: 90, search: true },
+    { label: '物料名称', prop: 'materialName', overHidden: true, search: true },
+    { label: '规格型号', prop: 'specification', overHidden: true },
+    { label: '数量', prop: 'qty', overHidden: true },
+  ],
+});
+
+const checkType = computed(() => props.checkType);
+const resolvedDefaultChecked = computed(() => props.defaultChecked || props.modelValue);
+
+const ids = computed(() => Array.from(new Set(selectionList.value.map((item) => item.id))).join(','));
+const names = computed(() => Array.from(new Set(selectionList.value.map((item) => item.realName))).join(','));
+
+function applyCustomOption() {
+  if (!props.customOption) return;
+  const { column, userProps } = props.customOption;
+  if (Array.isArray(column) && column.length) {
+    option.column = column;
+  }
+  if (userProps && typeof userProps === 'object') {
+    Object.assign(tableProps, userProps);
+  }
+}
+
+function toggleSelectionType(val) {
+  const radioColumn = findObject(option.column, 'radio');
+  if (val === 'radio') {
+    option.selection = false;
+    if (radioColumn && typeof radioColumn === 'object') radioColumn.hide = false;
+  } else {
+    option.selection = true;
+    if (radioColumn && typeof radioColumn === 'object') radioColumn.hide = true;
+  }
+}
+
+watch(
+  () => props.checkType,
+  (val) => {
+    toggleSelectionType(val);
+  },
+  { immediate: true }
+);
+
+watch(
+  resolvedDefaultChecked,
+  (val) => {
+    if (visible.value && val) {
+      changeDefaultChecked();
+    }
+  },
+  { deep: true }
+);
+
+onMounted(() => {
+  init();
+});
+
+function init() {
+  if (isInit.value) return;
+  applyCustomOption();
+  isInit.value = true;
+}
+
+function handleConfirm() {
+  if (!selectionList.value.length) {
+    showToast({ message: '请选择至少一条数据' });
+    return;
+  }
+  emit('onConfirm', selectionList.value);
+  handleClose();
+}
+
+function handleClose() {
+  visible.value = false;
+}
+
+function searchReset() {
+  query.value = {};
+  onLoad(page.value);
+}
+
+async function searchChange(params, done) {
+  query.value = params;
+  page.value.current = 1;
+  try {
+    await onLoad(page.value, params);
+  } finally {
+    if (typeof done === 'function') done();
+  }
+}
+
+function onSelectionChange(list = []) {
+  selectionList.value = list;
+}
+
+function onCurrentChange(val) {
+  page.value.current = val;
+}
+
+function onSizeChange(val) {
+  page.value.pageSize = val;
+}
+
+function rowClick(row) {
+  if (props.checkType === 'radio') {
+    selectionList.value = [row];
+    form.value.radio = row.id;
+  } else {
+    crudRef.value?.toggleSelection?.([row]);
+  }
+}
+
+function selectionClear() {
+  selectionList.value = [];
+  crudRef.value?.toggleSelection?.();
+}
+
+async function changeDefaultChecked() {
+  const defaultChecked = resolvedDefaultChecked.value;
+  if (!defaultChecked) return;
+  if (props.checkType === 'checkbox') {
+    const checks = Array.isArray(defaultChecked)
+      ? defaultChecked
+      : String(defaultChecked)
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean);
+    if (!checks.length) return;
+    await nextTick();
+    checks.forEach(async (c) => {
+      let row = data.value.find((d) => d.id == c) || selectionList.value.find((d) => d.id == c);
+      if (!row) {
+        try {
+          const res = await getMaterialDetail(c);
+          row = res.data?.data;
+        } catch (error) {
+          row = null;
         }
       }
-    },
-    onLoad(page, params = {}) {
-      this.loading = true;
-      const param = {
-        current: page.current || 1,
-        size: page.pageSize || 10,
-        ...Object.assign(params, this.query),
-      };
-      this.$axios.get(this.voUrl, { params: param }).then(res => {
-        this.page.total = res.data.data.total;
-        this.data = res.data.data.records;
-        this.loading = false;
+      if (row) {
+        crudRef.value?.toggleRowSelection?.(row, true);
+      }
+    });
+  } else {
+    const targetId = typeof defaultChecked === 'object' ? defaultChecked.id : defaultChecked;
+    if (!targetId) return;
+    let row = data.value.find((d) => d.id == targetId);
+    if (!row) {
+      try {
+        const res = await getMaterialDetail({ materialCode: targetId });
+        row = res.data?.data;
+      } catch (error) {
+        row = null;
+      }
+    }
+    if (row) {
+      selectionList.value = [row];
+      form.value.radio = targetId;
+    } else {
+      selectionList.value = [];
+      form.value.radio = '';
+    }
+  }
+}
 
-        this.changeDefaultChecked();
-      });
-    },
+async function onLoad(pageInfo, params = {}) {
+  loading.value = true;
+  const mergedQuery = { ...params, ...query.value };
+  const size = pageInfo.pageSize || pageInfo.size || 10;
+  const requestParams = {
+    current: pageInfo.current || 1,
+    size,
+    ...mergedQuery,
+  };
+  try {
+    const res = await request.get(props.voUrl, { params: requestParams });
+    const responseData = res.data?.data || {};
+    page.value.total = responseData.total || 0;
+    data.value = responseData.records || [];
+    await changeDefaultChecked();
+  } finally {
+    loading.value = false;
+  }
+}
+
+defineExpose({
+  visible,
+  open: () => {
+    visible.value = true;
   },
-};
+  close: handleClose,
+  selectionClear,
+  ids,
+  names,
+});
 </script>
-<style lang="scss">
+
+<style scoped lang="scss">
 .nf-dialog {
-  display: flex;
-  flex-direction: column;
-  margin: 0 !important;
-  position: absolute;
-  top: 40%;
-  left: 50%;
-  transform: translate(-50%, -40%);
-  max-height: calc(100% - 30px);
-  max-width: calc(100% - 30px);
-  .el-dialog__body {
+  width: 90vw;
+  max-width: 960px;
+  .nf-dialog__container {
+    display: flex;
+    flex-direction: column;
+    max-height: 80vh;
+  }
+  .nf-dialog__header {
+    padding: 16px 20px 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .nf-dialog__body {
     flex: 1;
+    padding: 12px 20px 0;
     overflow: auto;
   }
+  .nf-dialog__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 12px 20px 20px;
+  }
+}
+
+.nf-radio-icon {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid #c8c9cc;
+  box-sizing: border-box;
+}
+
+.nf-radio-icon--checked {
+  border-color: var(--van-primary-color);
+  background: radial-gradient(circle, var(--van-primary-color) 0%, var(--van-primary-color) 60%, transparent 65%);
 }
 </style>


### PR DESCRIPTION
## Summary
- rebuild the nf-prdmo-select dialog with Vue 3 setup syntax plus Vant 4 popup, radio, and button components while keeping the CRUD table behavior intact
- refresh the wf-prdmo-select custom field so it uses Vant Field, works with the new dialog API, and keeps the model sync/change callbacks

## Testing
- `npm run test` *(fails: Vitest cannot resolve the `@/router` alias when loading src/utils/http.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1f58441883278470a346af2704a5)