### PR TITLE
Update warehousing entry nav title to indicate assembly tool returns

### DIFF
--- a/src/components/dc-ui/components/SelectDialog/index.vue
+++ b/src/components/dc-ui/components/SelectDialog/index.vue
@@ -3,10 +3,9 @@
     class="dc-select-dialog"
     :style="{ width, '--dc-select-dialog-footer-height': footerHeight }"
   >
-    <div v-if="$slots.default" class="dc-select-dialog__trigger" :class="{ disabled }">
-      <div class="dc-select-dialog__slot" @click="openPopup">
-        <slot></slot>
-      </div>
+    <div v-if="$slots.customize" @click="openPopup"><slot name="customize"></slot></div>
+    <div v-else-if="$slots.default" class="dc-select-dialog__trigger" :class="{ disabled }">
+      <div class="dc-select-dialog__slot" @click="openPopup"><slot></slot></div>
       <div class="dc-select-dialog__icons">
         <van-icon
           v-if="displayClearIcon"
@@ -75,7 +74,7 @@
       @close="handleClose"
     >
       <div class="dc-select-dialog__header">
-        <span class="dc-select-dialog__title">{{ popupTitle }}</span>
+        <span class="dc-select-dialog__title">{{ popupTitle }} </span>
       </div>
 
       <div v-loading="loading" class="dc-select-dialog__body">

--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -143,7 +143,7 @@ export default {
       component: () => import('@/views/apps/OutsourcingQuotation.vue'),
     },
     {
-      path: 'warehouse-record',
+      path: 'warehouse-record/out',
       name: 'appsWarehouseRecord',
       meta: { title: '装配工具借用', requiresAuth: true },
       component: () => import('@/views/apps/warehouseRecord/outboundOrder.vue'),

--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -149,6 +149,12 @@ export default {
       component: () => import('@/views/apps/warehouseRecord/outboundOrder.vue'),
     },
     {
+      path: 'warehouse-record/entry',
+      name: 'appsWarehousingEntry',
+      meta: { title: '装配工具归还', requiresAuth: true },
+      component: () => import('@/views/apps/warehouseRecord/warehousingEntry.vue'),
+    },
+    {
       path: 'warehouse-record/outbound/:id',
       name: 'appsWarehouseRecordOutboundSubmit',
       meta: { title: '出库提交', requiresAuth: true },

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -9,9 +9,9 @@ export function goBackOrHome(router, fallback = '/home') {
     (historyState && historyState.back !== null && historyState.back !== undefined) ||
     window.history.length > 1;
 
-  if (canGoBack) {
-    router.back();
-  } else {
+  if (fallback) {
     router.replace(fallback);
+  } else {
+    router.back();
   }
 }

--- a/src/views/apps/index.vue
+++ b/src/views/apps/index.vue
@@ -73,6 +73,7 @@ const apps = [
   // { label: '出货资料上传', icon: '/images/apps/出货资料上传.svg', routeName: 'appsShipmentUpload' },
   { label: '外协核价', icon: '/images/apps/外协核价.svg', routeName: 'appsOutsourcingQuotation' },
   { label: '装配工具借用', icon: '/images/apps/测试.svg', routeName: 'appsWarehouseRecord' },
+  { label: '装配工具归还', icon: '/images/apps/测试.svg', routeName: 'appsWarehousingEntry' },
   { label: '自助出库', icon: '/images/apps/自助出库.svg', routeName: 'appsSelfOutbound' },
   { label: '铭牌绑定', icon: '/images/apps/名牌绑定.svg', routeName: 'appsNameplateBinding' },
 ];

--- a/src/views/apps/warehouseRecord/outboundOrder.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder.vue
@@ -17,27 +17,6 @@
         <van-nav-bar ref="navRef" title="装配工具借用" fixed left-arrow @click-left="goBack" />
       </template>
 
-      <template #filters="{ apply }">
-        <van-cell-group inset class="filter-card">
-          <van-field
-            label="出库类型"
-            readonly
-            :model-value="resolveOutTypeLabel(queryParams.outStockType)"
-          />
-          <dc-select-dialog
-            v-model="selectedWarehouse"
-            label="仓库"
-            object-name="warehouse"
-            :multiple="false"
-            return-type="object"
-            placeholder="请选择仓库"
-          />
-          <van-button type="primary" block size="small" class="filter-card__action" @click="apply"
-            >筛选</van-button
-          >
-        </van-cell-group>
-      </template>
-
       <template #item="{ item }">
         <div class="card" @click="handleEdit(item)">
           <div class="card__header">
@@ -120,7 +99,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { showConfirmDialog, showToast } from 'vant';
 import Api from '@/api';
@@ -136,17 +115,14 @@ const listRef = ref(null);
 const keyword = ref('');
 const activeStatus = ref(null);
 const queryParams = ref({
-  outStockType: '',
-  warehouseId: null,
+  outStockType: 'DC_WMS_OUT_TYPE_BORROW',
 });
-const selectedWarehouse = ref(null);
 
 const outTypeDict = ref([]);
 const outStatusDict = ref([]);
 
 const statusOptions = computed(() => {
   const list = outStatusDict.value || [];
-  console.log(list);
   return [{ label: '全部', value: null }, ...list];
 });
 
@@ -164,26 +140,11 @@ const loadDicts = async () => {
   outStatusDict.value = (await dictStore.get('DC_WMS_OUT_STATUS')) || [];
 };
 
-const resolveOutTypeLabel = (value) => {
-  const list = outTypeDict.value || [];
-  const hit = list.find((item) => item?.dictKey === value || item?.value === value);
-  return hit?.dictValue || hit?.label || value || '';
-};
-
 onMounted(() => {
   loadDicts();
 });
 
-watch(
-  selectedWarehouse,
-  (val) => {
-    const row = val && typeof val === 'object' ? val : null;
-    queryParams.value.warehouseId = row?.id ?? row?.warehouseId ?? null;
-  },
-  { immediate: true }
-);
-
-async function fetcher({ pageNo, pageSize, keyword, status, outStockType, warehouseId }) {
+async function fetcher({ pageNo, pageSize, keyword, status, outStockType }) {
   const params = {
     current: pageNo,
     size: pageSize,
@@ -192,7 +153,6 @@ async function fetcher({ pageNo, pageSize, keyword, status, outStockType, wareho
   if (trimmedKeyword) params.outStockCode = trimmedKeyword;
   if (status) params.outStockStatus = status;
   if (outStockType) params.outStockType = outStockType;
-  if (warehouseId) params.warehouseId = warehouseId;
 
   const res = await Api.application.outboundOrder.list(params);
   const { code, data, msg } = res?.data || {};
@@ -227,7 +187,7 @@ const handleDelete = async (row) => {
 };
 
 const goBack = () => {
-  goBackOrHome(router);
+  goBackOrHome(router, '/apps');
 };
 </script>
 

--- a/src/views/apps/warehouseRecord/outboundOrder/components/OutboundReadonlyStep.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder/components/OutboundReadonlyStep.vue
@@ -3,45 +3,38 @@
     <van-form>
       <div class="form-group-title">基本信息</div>
       <van-cell-group inset>
-        <van-field label="出库类型" label-align="top" :model-value="outStockTypeLabel" readonly />
-        <van-field label="仓库名称" label-align="top">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              objectName="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="申请人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.applicantId"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="处理人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
+        <van-field label="出库类型" :model-value="outStockTypeLabel" readonly />
+        <dc-select-dialog
+          v-model="formData.warehouseId"
+          label="仓库名称"
+          placeholder="请点击选择仓库"
+          object-name="warehouse"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple-limit="1"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :multiple-limit="1"
+          :disabled="isShow"
+        />
         <van-field
           v-model="formData.remark"
           label="备注"
-          label-align="top"
           type="textarea"
           rows="2"
           placeholder="请输入备注"
@@ -63,7 +56,11 @@
               <div>单位：{{ item.productUnit || '-' }}</div>
               <div>
                 仓位：
-                <dc-view v-model="item.locationId" objectName="warehouseLocation" showKey="locationName" />
+                <dc-view
+                  v-model="item.locationId"
+                  object-name="warehouseLocation"
+                  show-key="locationName"
+                />
               </div>
             </div>
           </template>

--- a/src/views/apps/warehouseRecord/outboundOrder/components/step1.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder/components/step1.vue
@@ -1,202 +1,167 @@
 <template>
-  <div class="wrap-left-form">
-    <van-form ref="ruleFormRef">
-      <div class="form-group-title">基本信息</div>
-      <van-cell-group inset>
-        <van-field
-          label="出库类型"
-          label-align="top"
-          :model-value="outStockTypeLabel"
-          readonly
-          is-link
-          @click="showOutTypePicker = true"
-        />
-        <van-popup v-model:show="showOutTypePicker" position="bottom" round>
-          <van-picker
-            :columns="outStockTypeOptions"
-            @confirm="handleOutTypeConfirm"
-            @cancel="showOutTypePicker = false"
-          />
-        </van-popup>
-        <van-field label="仓库名称" label-align="top">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              objectName="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :params="{
-                stockType: getStockType(formData.outStockType),
-              }"
-              @change="handleWarehouseChange"
-            />
-          </template>
-        </van-field>
-        <van-field label="申请人" label-align="top">
-          <template #input>
-            <dc-select-user v-model="formData.applicantId" placeholder="请选择" :multipleLimit="1" />
-          </template>
-        </van-field>
-        <van-field label="处理人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multipleLimit="1"
-            />
-          </template>
-        </van-field>
-        <van-field
-          v-model="formData.remark"
-          label="备注"
-          label-align="top"
-          type="textarea"
-          rows="2"
-          placeholder="请输入备注"
-        />
-        <van-field
-          v-if="formData.reject"
-          v-model="formData.reject"
-          label="驳回原因"
-          label-align="top"
-          type="textarea"
-          rows="2"
-          readonly
-        />
-      </van-cell-group>
-      <div class="form-group-title">出库明细</div>
-      <dc-select-dialog-v2
-        v-if="formData.warehouseId"
-        objectName="warehouseCount"
-        :multiple="true"
-        :multiple-limit="0"
+  <van-form ref="ruleFormRef">
+    <div class="form-group-title">基本信息</div>
+    <van-cell-group inset>
+      <dc-selector
+        v-model="formData.outStockType"
+        label="出库类型"
+        placeholder="请点击选择出库类型"
+        title="出库类型"
+        :options="DC_WMS_OUT_TYPE_WMS"
+        disabled
+      />
+
+      <dc-select-dialog
+        v-model="formData.warehouseId"
+        placeholder="请点击选择仓库"
+        label="仓库名称"
+        object-name="warehouse"
+        type="input"
+        return-type="string"
+        :multiple="false"
+        :multiple-limit="1"
         :clearable="true"
-        :params="{ warehouseId: ids }"
-        @change="handleSerchDetail"
-      >
-        <template #search-items="{ queryParams, currentObject }">
-          <div class="dialog-search-box">
-            <van-field
-              v-model="queryParams.mtoNo"
-              label="计划跟踪号"
-              label-align="top"
-              placeholder="请输入计划跟踪号"
-            />
-            <van-field
-              v-model="queryParams[currentObject?.defaultLabel]"
-              :placeholder="currentObject?.placeholder"
-              label="物料名称"
-              label-align="top"
-              clearable
-            />
-          </div>
-        </template>
-        <van-button class="mb-5" type="primary">查询明细</van-button>
-      </dc-select-dialog-v2>
-      <van-button v-else class="mb-5" type="primary" @click="handleClickQueryDetail">
-        查询明细
-      </van-button>
-      <van-cell-group inset class="tabel-border">
-        <van-cell
-          v-for="(item, index) in formData.detailList"
-          :key="index"
-          :title="item.productName"
-          :label="`编码：${item.productCode || '-'}`"
-        >
-          <template #value>
-            <div class="detail-values">
-              <div>规格：{{ item.productSpec || '-' }}</div>
-              <div>数量：{{ item.productQty ?? '-' }}</div>
-              <div>单位：{{ item.productUnit || '-' }}</div>
-              <div>
-                仓位：
-                <dc-view
-                  v-model="item.locationId"
-                  objectName="warehouseLocation"
-                  showKey="locationName"
-                />
-              </div>
-              <div class="detail-actions">
-                <van-button size="small" type="primary" plain @click="handleUpdate(item)">
-                  编辑
-                </van-button>
-                <van-button size="small" type="danger" plain @click="removeEvaluate(item)">
-                  删除
-                </van-button>
-              </div>
-            </div>
-          </template>
-        </van-cell>
-      </van-cell-group>
-      <div class="form-itme-btn">
-        <van-button type="primary" block @click="submitForm">保存</van-button>
-        <van-button type="primary" block @click="submitAudit">审核</van-button>
-        <van-button block @click="cancelSubmit">取消</van-button>
-      </div>
-    </van-form>
-  </div>
-  <van-popup v-model:show="open" position="right" class="drawer-popup" @close="closeDrawer">
-    <div class="drawer-content">
-      <div class="drawer-title">{{ title }}</div>
-      <van-form ref="formRef">
-        <van-cell-group inset>
+        :params="{
+          stockType: getStockType(formData.outStockType),
+        }"
+        disabled
+        @change="handleWarehouseChange"
+      />
+
+      <dc-select-dialog
+        v-model="formData.applicantId"
+        label="申请人"
+        placeholder="请选择"
+        object-name="user"
+        :multiple="false"
+        return-type="string"
+      />
+
+      <dc-select-dialog
+        v-model="formData.processingPersonnel"
+        label="处理人"
+        placeholder="请选择"
+        object-name="user"
+        :multiple="false"
+        return-type="string"
+      />
+
+      <van-field
+        v-model="formData.remark"
+        label="备注"
+        type="textarea"
+        rows="2"
+        placeholder="请输入备注"
+      />
+
+      <van-field
+        v-if="formData.reject"
+        v-model="formData.reject"
+        label="驳回原因"
+        type="textarea"
+        rows="2"
+        readonly
+      />
+    </van-cell-group>
+
+    <div class="form-group-title">出库明细</div>
+
+    <dc-select-dialog
+      v-if="formData.warehouseId"
+      object-name="warehouseCount"
+      :multiple="true"
+      :multiple-limit="0"
+      :clearable="true"
+      :params="{ warehouseId: ids }"
+      @change="handleSerchDetail"
+    >
+      <template #customize>
+        <van-button class="mb-5" type="primary" size="mini">查询明细</van-button>
+      </template>
+
+      <template #search-items="{ queryParams, currentObject }">
+        <div class="dialog-search-box">
           <van-field
-            v-model="formDataTable.productName"
+            v-model="queryParams.mtoNo"
+            label="计划跟踪号"
+            placeholder="请输入计划跟踪号"
+          />
+          <van-field
+            v-model="queryParams[currentObject?.defaultLabel]"
+            :placeholder="currentObject?.placeholder"
             label="物料名称"
-            label-align="top"
-            placeholder="物料名称"
-            readonly
+            clearable
           />
-          <van-field
-            v-model="formDataTable.productCode"
-            label="物料编码"
-            label-align="top"
-            placeholder="物料编码"
-            readonly
+        </div>
+      </template>
+    </dc-select-dialog>
+
+    <!-- 出库明细：一行一项（每条明细一行展示：名称/数量/仓位/删除） -->
+    <div v-for="(item, index) in formData.detailList" :key="index" class="card__meta">
+      <div class="row">
+        <span class="label">物料名称</span>
+        <span class="value">
+          {{ item.productName || '-' }}
+        </span>
+      </div>
+      <div class="row">
+        <span class="label">物料编码</span>
+        <span class="value">
+          {{ item.productCode || '-' }}
+        </span>
+      </div>
+      <div class="row">
+        <span class="label">规格型号</span>
+        <span class="value">
+          {{ item.productSpec || '-' }}
+        </span>
+      </div>
+      <div class="row">
+        <span class="label">数量</span>
+        <span class="value">
+          <van-stepper
+            v-model="item.productQty"
+            integer
+            min="0"
+            :max="999999999"
+            theme="round"
+            button-size="22"
+            input-width="70"
           />
-          <van-field
-            v-model="formDataTable.productSpec"
-            label="规格型号"
-            label-align="top"
-            placeholder="规格型号"
-            readonly
-          />
-          <van-field label="数量" label-align="top">
-            <template #input>
-              <van-stepper v-model="formDataTable.productQty" min="1" :max="numbers" />
-            </template>
-          </van-field>
-          <van-field
-            v-model="formDataTable.productUnit"
-            label="单位"
-            label-align="top"
-            placeholder="单位"
-            readonly
-          />
-          <van-field label="仓位编号" label-align="top">
-            <template #input>
-              <dc-view
-                v-model="formDataTable.locationId"
-                objectName="warehouseLocation"
-                showKey="locationName"
-              />
-            </template>
-          </van-field>
-        </van-cell-group>
-      </van-form>
-      <div class="drawer-footer">
-        <van-button type="primary" block @click="submitFormTable">提交</van-button>
-        <van-button block @click="closeDrawer">取消</van-button>
+        </span>
+      </div>
+      <div class="row">
+        <span class="label">单位</span>
+        <span class="value">
+          {{ item.productUnit || '-' }}
+        </span>
+      </div>
+      <div class="row">
+        <span class="label">仓位编号</span>
+        <span class="value"
+          ><dc-view
+            v-model="item.locationId"
+            object-name="warehouseLocation"
+            show-key="locationName"
+        /></span>
+      </div>
+      <div class="row">
+        <van-button size="mini" type="danger" plain @click="removeEvaluate(item)">
+          删除
+        </van-button>
       </div>
     </div>
-  </van-popup>
+
+    <div class="form-itme-btn">
+      <van-button type="primary" size="mini" block @click="submitForm">保存</van-button>
+      <van-button type="primary" size="mini" block @click="submitAudit">审核</van-button>
+      <van-button size="mini" block @click="cancelSubmit">取消</van-button>
+    </div>
+  </van-form>
 </template>
 
 <script setup name="customerSubmit">
-import { reactive, toRefs, getCurrentInstance, watch, computed, ref, onMounted } from 'vue';
+import { reactive, toRefs, getCurrentInstance, watch, computed, onMounted } from 'vue';
 import Api from '@/api';
 import { useRouter, useRoute } from 'vue-router';
 
@@ -220,6 +185,7 @@ const router = useRouter();
 const route = useRoute();
 const { proxy } = getCurrentInstance();
 const userinfo = computed(() => proxy.$store.getters.userInfo);
+
 // 子组件调用父组件方法
 const emit = defineEmits(['out-stock-type-change']);
 
@@ -227,96 +193,22 @@ const props = defineProps({
   // 详情
   info: {
     type: Object,
-    default: {},
+    default: () => ({}),
   },
 });
+
 const { DC_WMS_OUT_TYPE_WMS } = proxy.dicts(['DC_WMS_OUT_TYPE_WMS']);
-const showOutTypePicker = ref(false);
-const outStockTypeOptions = computed(() =>
-  (DC_WMS_OUT_TYPE_WMS?.value || []).map((item) => ({
-    text: item.dictValue,
-    value: item.dictKey,
-  }))
-);
 
 const pageData = reactive({
-  loading: false,
-  formRules: {
-    warehouseId: [
-      {
-        required: true,
-        validator(_, value, callback) {
-          if ([null, undefined, ''].includes(value)) {
-            callback(new Error('请选择仓库名称'));
-          } else {
-            callback();
-          }
-        },
-        trigger: ['blur'],
-      },
-    ],
-    processingPersonnel: [
-      {
-        required: true,
-        validator(_, value, callback) {
-          if ([null, '', undefined].includes(value)) {
-            callback(new Error('请选择处理人'));
-          }
-          if (value && value?.split?.(',')?.length > 1) {
-            callback(new Error('不允许有多个处理人'));
-          } else {
-            callback();
-          }
-        },
-        trigger: 'blur',
-      },
-    ],
-    outStockType: [
-      {
-        required: true,
-        validator(_, value, callback) {
-          if ([null, undefined, ''].includes(value)) {
-            callback(new Error('请选择出库类型'));
-          } else {
-            callback();
-          }
-        },
-        trigger: ['blur'],
-      },
-    ],
-  },
-  rules: {},
   formData: {
-    outStockType: 'DC_WMS_OUT_TYPE_OTHER',
+    outStockType: 'DC_WMS_OUT_TYPE_BORROW',
+    detailList: [],
   },
-  formDataTable: {},
-  open: false,
-  title: '',
-  editIndex: null,
   isDisabled: true,
   ids: null,
-  numbers: null,
 });
 
-const {
-  loading,
-  formRules,
-  rules,
-  formData,
-  formDataTable,
-  open,
-  title,
-  editIndex,
-  isDisabled,
-  ids,
-  numbers,
-} = toRefs(pageData);
-
-const outStockTypeLabel = computed(() => {
-  const list = DC_WMS_OUT_TYPE_WMS?.value || [];
-  const hit = list.find((item) => item.dictKey === formData.value.outStockType);
-  return hit?.dictValue || '';
-});
+const { formData, isDisabled, ids } = toRefs(pageData);
 
 const validateForm = async () => {
   const formRef = proxy.$refs.ruleFormRef;
@@ -325,17 +217,17 @@ const validateForm = async () => {
   }
 };
 
-const handleOutTypeConfirm = (value) => {
-  const selected = Array.isArray(value) ? value[0] : value;
-  formData.value.outStockType = selected?.value ?? selected;
-  showOutTypePicker.value = false;
-};
-
 onMounted(() => {
   formData.value.applicantId = userinfo.value.user_id;
-  if (route.params.id != 'create') {
+  formData.value.warehouseId = '2008344171069898753';
+
+  if (route.params.id !== 'create') {
     const timer = setTimeout(() => {
-      formData.value = props.info;
+      formData.value = {
+        ...props.info,
+        // 保底，避免 detailList 为空时报错
+        detailList: props.info?.detailList || [],
+      };
       clearTimeout(timer);
     }, 300);
   }
@@ -345,30 +237,30 @@ onMounted(() => {
 watch(
   () => formData.value.outStockType,
   (newVal) => {
-    if (newVal) {
-      emit('out-stock-type-change', newVal);
-    }
+    if (newVal) emit('out-stock-type-change', newVal);
   }
 );
 
-// 确认创建
+// 保存
 const submitForm = async () => {
   try {
     await validateForm();
   } catch {
     return;
   }
+
   const warehouseId =
     typeof formData.value.warehouseId === 'object'
       ? formData.value.warehouseId?.id
       : formData.value.warehouseId;
+
   const form = {
     ...formData.value,
-    warehouseId: warehouseId,
+    warehouseId,
   };
 
   const res = await Api.application.outboundOrder.submit(form);
-  const { code, msg } = res.data;
+  const { code } = res.data;
   if (code === 200) {
     proxy.$message({ type: 'success', message: '保存成功' });
     router.push({
@@ -377,6 +269,7 @@ const submitForm = async () => {
     });
   }
 };
+
 // 审核
 const submitAudit = () => {
   (async () => {
@@ -385,17 +278,19 @@ const submitAudit = () => {
     } catch {
       return;
     }
+
     const warehouseId =
       typeof formData.value.warehouseId === 'object'
         ? formData.value.warehouseId?.id
         : formData.value.warehouseId;
+
     const form = {
       ...formData.value,
-      warehouseId: warehouseId,
+      warehouseId,
     };
 
     const res = await Api.application.outboundOrder.submitAudit(form);
-    const { code, msg } = res.data;
+    const { code } = res.data;
     if (code === 200) {
       proxy.$message({ type: 'success', message: '审核成功' });
       router.push({
@@ -406,31 +301,7 @@ const submitAudit = () => {
   })();
 };
 
-// 表格编辑
-const handleUpdate = (row) => {
-  editIndex.value = formData.value.detailList.findIndex((item) => item === row);
-  if (editIndex.value !== -1) {
-    open.value = true;
-    numbers.value = row.productQty;
-    formDataTable.value = { ...row }; // 创建一个新对象，避免直接修改引用
-  }
-};
-
-// 提交修改
-const submitFormTable = async () => {
-  if (editIndex.value !== null && editIndex.value !== -1) {
-    // 编辑模式：更新原列表中的数据
-    formData.value.detailList[editIndex.value] = { ...formDataTable.value };
-    editIndex.value = null;
-  } else {
-    // 新增模式
-    formData.value.detailList.push({ ...formDataTable.value });
-  }
-  formDataTable.value = {}; // 清空表单
-  open.value = false; // 关闭抽屉
-};
-
-// 表格删除
+// 删除明细
 const removeEvaluate = async (row) => {
   const index = formData.value.detailList.findIndex((item) => item === row);
   if (index !== -1) {
@@ -438,35 +309,28 @@ const removeEvaluate = async (row) => {
   }
 };
 
-// 抽屉取消
-const closeDrawer = () => {
-  formDataTable.value = {};
-  open.value = false;
-};
 // 取消
 const cancelSubmit = () => {
   router.push({
-    path: '/wms/warehouseRecord/outboundOrder',
-    params: {},
+    path: '/apps/warehouse-record/out',
   });
 };
 
-//仓库监听事件
+// 仓库监听事件
 const handleWarehouseChange = async (row) => {
   formData.value.processingPersonnel = row.warehouseSupervisor;
   isDisabled.value = false;
   ids.value = row.id;
 };
 
-// 查询明细
+// 查询明细（把接口返回映射成 detailList）
 const handleSerchDetail = (row) => {
-  formData.value.detailList = row;
-  formData.value.detailList = row.map((item) => ({
+  formData.value.detailList = (row || []).map((item) => ({
     warehouseId: item.warehouseId,
     productName: item.productName,
     productCode: item.productCode,
     productSpec: item.productSpec,
-    productQty: item.number,
+    productQty: item.number, // 数量后续在 card 内直接改这个字段
     productUnit: item.unit,
     outStockId: item.locationId,
     warehouseCountId: item.id,
@@ -475,22 +339,11 @@ const handleSerchDetail = (row) => {
     mtoNo: item.mtoNo,
   }));
 };
-
-/** 查询详情点击 */
-const handleClickQueryDetail = () => {
-  if (!formData.value.warehouseId) {
-    proxy.$refs.ruleFormRef.validateField(['warehouseId']);
-    proxy.$message.error('请先选择基本信息里的仓库名称');
-  }
-};
 </script>
+
 <style lang="scss" scoped>
 .tabel-border {
   border: 1px solid #edeae8;
-}
-.wrap-left-form {
-  padding: 16px;
-  background: #f5f7fb;
 }
 .form-group-title {
   font-weight: 600;
@@ -498,11 +351,11 @@ const handleClickQueryDetail = () => {
   margin: 16px 4px 12px;
   font-size: 15px;
 }
-.wrap-left-form :deep(.van-cell-group) {
+:deep(.van-cell-group) {
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
-.wrap-left-form :deep(.van-cell) {
+:deep(.van-cell) {
   padding-left: 12px;
   padding-right: 12px;
 }
@@ -518,6 +371,12 @@ const handleClickQueryDetail = () => {
   gap: 4px;
   text-align: right;
 }
+.qty-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
 .detail-actions {
   display: flex;
   justify-content: flex-end;
@@ -525,10 +384,15 @@ const handleClickQueryDetail = () => {
   margin-top: 8px;
 }
 .form-itme-btn {
-  margin-top: 16px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 8px;
   display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 8px;
+  background-color: #fff;
 }
 .drawer-popup {
   width: 85%;
@@ -546,5 +410,23 @@ const handleClickQueryDetail = () => {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.card__meta {
+  margin-top: 8px;
+  color: #666;
+  font-size: 13px;
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 10px;
+}
+.card__meta .row {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.card__meta .label {
+  color: #888;
+  min-width: 40px;
 }
 </style>

--- a/src/views/apps/warehouseRecord/outboundOrder/components/step2.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder/components/step2.vue
@@ -3,45 +3,37 @@
     <van-form ref="ruleFormRef">
       <div class="form-group-title">基本信息</div>
       <van-cell-group inset>
-        <van-field label="出库类型" label-align="top" :model-value="outStockTypeLabel" readonly />
-        <van-field label="仓库名称" label-align="top">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              objectName="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="申请人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.applicantId"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="处理人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
+        <van-field label="出库类型" :model-value="outStockTypeLabel" readonly />
+        <dc-select-dialog
+          v-model="formData.warehouseId"
+          label="仓库名称"
+          placeholder="请点击选择仓库"
+          object-name="warehouse"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
         <van-field
           v-model="formData.remark"
           label="备注"
-          label-align="top"
           type="textarea"
           rows="2"
           placeholder="请输入备注"
@@ -65,8 +57,8 @@
                 仓位：
                 <dc-view
                   v-model="item.locationId"
-                  objectName="warehouseLocation"
-                  showKey="locationName"
+                  object-name="warehouseLocation"
+                  show-key="locationName"
                 />
               </div>
             </div>
@@ -104,13 +96,11 @@ const props = defineProps({
   },
 });
 const pageData = reactive({
-  loading: false,
-  rules: {},
   formData: {},
   isShow: true,
 });
 
-const { loading, rules, formData, isShow } = toRefs(pageData);
+const { formData, isShow } = toRefs(pageData);
 const rejectReason = ref('');
 const outStockTypeLabel = computed(() => {
   const list = DC_WMS_OUT_TYPE_WMS?.value || [];

--- a/src/views/apps/warehouseRecord/outboundOrder/components/step3.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder/components/step3.vue
@@ -3,45 +3,37 @@
     <van-form ref="ruleFormRef">
       <div class="form-group-title">基本信息</div>
       <van-cell-group inset>
-        <van-field label="出库类型" label-align="top" :model-value="outStockTypeLabel" readonly />
-        <van-field label="仓库名称" label-align="top">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              objectName="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="申请人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.applicantId"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
-        <van-field label="处理人" label-align="top">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multipleLimit="1"
-              :disabled="isShow"
-            />
-          </template>
-        </van-field>
+        <van-field label="出库类型" :model-value="outStockTypeLabel" readonly />
+        <dc-select-dialog
+          v-model="formData.warehouseId"
+          label="仓库名称"
+          placeholder="请点击选择仓库"
+          object-name="warehouse"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
         <van-field
           v-model="formData.remark"
           label="备注"
-          label-align="top"
           type="textarea"
           rows="2"
           placeholder="请输入备注"
@@ -65,8 +57,8 @@
                 仓位：
                 <dc-view
                   v-model="item.locationId"
-                  objectName="warehouseLocation"
-                  showKey="locationName"
+                  object-name="warehouseLocation"
+                  show-key="locationName"
                 />
               </div>
             </div>

--- a/src/views/apps/warehouseRecord/outboundOrder/index.vue
+++ b/src/views/apps/warehouseRecord/outboundOrder/index.vue
@@ -3,9 +3,7 @@
     <div class="wrap-left">
       <!-- 移动端：顶部横向步骤条，减少占高 -->
       <van-steps :active="step" direction="horizontal">
-        <van-step v-for="(item, index) in dictData" :key="index">
-          {{ index + 1 }}
-        </van-step>
+        <van-step v-for="(d, index) in dictData" :key="index">{{ d.label }}</van-step>
       </van-steps>
 
       <!-- 当前步骤标题：让用户始终知道正在填什么 -->
@@ -62,7 +60,7 @@ const { DC_WMS_OUT_STATUS } = proxy.dicts(['DC_WMS_OUT_STATUS']);
 const dictOutStockStatus = (value) => {
   let dcWmsOutStatus = DC_WMS_OUT_STATUS.value;
   if (value === 'DC_WMS_OUT_TYPE_BORROW') {
-    dictData.value = dcWmsOutStatus.filter((item) => item.dictKey !== 'DC_WMS_OUT_STATUS_C');
+    dictData.value = dcWmsOutStatus.filter((item) => item.value !== 'DC_WMS_OUT_STATUS_C');
     console.log(dictData.value);
   } else {
     dictData.value = dcWmsOutStatus.slice(0, 4);
@@ -173,7 +171,6 @@ const handleOutStockTypeChange = (newOutStockType) => {
 /* 顶部步骤条：卡片样式 */
 :deep(.van-steps) {
   margin-bottom: 12px;
-  background: #fff;
   border-radius: 12px;
   padding: 12px 10px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
@@ -192,12 +189,6 @@ const handleOutStockTypeChange = (newOutStockType) => {
   line-height: 16px;
   word-break: break-all;
 }
-
-/* 横向步骤条：把标题隐藏掉，只保留圆点/序号逻辑 */
-:deep(.van-steps--horizontal .van-step__title) {
-  display: none;
-}
-
 
 /* 如果 step 组件内部是表单：强制单列更舒服 */
 :deep(.custom-form) {

--- a/src/views/apps/warehouseRecord/warehousingEntry.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry.vue
@@ -14,7 +14,7 @@
       @add="handleAdd"
     >
       <template #nav>
-        <van-nav-bar ref="navRef" title="装配工具借用" fixed left-arrow @click-left="goBack" />
+        <van-nav-bar ref="navRef" title="装配工具归还" fixed left-arrow @click-left="goBack" />
       </template>
 
       <template #filters="{ apply }">

--- a/src/views/apps/warehouseRecord/warehousingEntry.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry.vue
@@ -17,58 +17,36 @@
         <van-nav-bar ref="navRef" title="装配工具归还" fixed left-arrow @click-left="goBack" />
       </template>
 
-      <template #filters="{ apply }">
-        <van-cell-group inset class="filter-card">
-          <dc-selector
-            v-model="queryParams.inType"
-            label="入库类型"
-            :options="inTypeOptions"
-            placeholder="请选择入库类型"
-          />
-          <dc-select-dialog
-            v-model="selectedWarehouse"
-            label="仓库"
-            object-name="warehouse"
-            :multiple="false"
-            return-type="object"
-            placeholder="请选择仓库"
-          />
-          <van-button type="primary" block size="small" class="filter-card__action" @click="apply"
-            >筛选</van-button
-          >
-        </van-cell-group>
-      </template>
-
       <template #item="{ item }">
         <div class="card" @click="handleEdit(item)">
           <div class="card__header">
             <div class="title">入库单号：{{ item.inStockCode ?? '—' }}</div>
-            <van-tag plain round class="status-tag">
-              {{ resolveStatusLabel(item.inStockStatus) }}
-            </van-tag>
+            <dc-dict :value="item.inStockStatus" :options="inStatusDict" />
           </div>
 
           <div class="card__meta">
             <div class="row">
               <span class="label">入库类型</span>
-              <span class="value">{{ resolveInTypeLabel(item.inType) }}</span>
+              <span class="value">
+                <dc-dict :value="item.inType" :options="inTypeDict" />
+              </span>
             </div>
             <div class="row">
               <span class="label">仓库</span>
               <span class="value">
-                <dc-view :value="item.warehouseId" object-name="warehouse" />
+                <dc-view v-model="item.warehouseId" object-name="warehouse" />
               </span>
             </div>
             <div class="row">
               <span class="label">申请人</span>
               <span class="value">
-                <dc-view :value="item.applicantId" object-name="user" />
+                <dc-view v-model="item.applicantId" object-name="user" />
               </span>
             </div>
             <div class="row">
               <span class="label">处理人</span>
               <span class="value">
-                <dc-view :value="item.processingPersonnel" object-name="user" />
+                <dc-view v-model="item.processingPersonnel" object-name="user" />
               </span>
             </div>
             <div class="row">
@@ -139,10 +117,9 @@ const listRef = ref(null);
 const keyword = ref('');
 const activeStatus = ref(null);
 const queryParams = ref({
-  inType: null,
+  inType: 'DC_WMS_IN_TYPE_RETURN',
   warehouseId: null,
 });
-const selectedWarehouse = ref(null);
 
 const inTypeDict = ref([]);
 const inStatusDict = ref([]);
@@ -158,10 +135,13 @@ const inTypeOptions = computed(() =>
 
 const statusOptions = computed(() => {
   const list = inStatusDict.value || [];
-  return [{ label: '全部', value: null }, ...list.map((item) => ({
-    label: item.dictValue,
-    value: item.dictKey,
-  }))];
+  return [
+    { label: '全部', value: null },
+    ...list.map((item) => ({
+      label: item.dictValue,
+      value: item.dictKey,
+    })),
+  ];
 });
 
 const resolveNavEl = () => {
@@ -173,14 +153,6 @@ const resolveNavEl = () => {
   return null;
 };
 
-const resolveDictLabel = (list = [], value) => {
-  const hit = list.find((item) => item.dictKey === value);
-  return hit?.dictValue ?? value ?? '—';
-};
-
-const resolveInTypeLabel = (value) => resolveDictLabel(inTypeDict.value || [], value);
-const resolveStatusLabel = (value) => resolveDictLabel(inStatusDict.value || [], value);
-
 const loadDicts = async () => {
   inTypeDict.value = (await dictStore.get('DC_WMS_IN_TYPE_WMS')) || [];
   inStatusDict.value = (await dictStore.get('DC_WMS_IN_STATUS')) || [];
@@ -189,15 +161,6 @@ const loadDicts = async () => {
 onMounted(() => {
   loadDicts();
 });
-
-watch(
-  selectedWarehouse,
-  (val) => {
-    const row = val && typeof val === 'object' ? val : null;
-    queryParams.value.warehouseId = row?.id ?? row?.warehouseId ?? null;
-  },
-  { immediate: true }
-);
 
 async function fetcher({ pageNo, pageSize, keyword, status, inType, warehouseId }) {
   const params = {

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
@@ -17,17 +17,18 @@
             @cancel="showInTypePicker = false"
           />
         </van-popup>
-        <van-field label="仓库名称">
+        <van-field>
           <template #input>
             <dc-select-dialog
               v-model="formData.warehouseId"
+              label="仓库名称"
               :disabled="[null, '', undefined].includes(formData.inType)"
               :placeholder="
                 [null, '', undefined].includes(formData.inType)
                   ? '请先选择入库类型'
                   : '请点击选择仓库'
               "
-              objectName="warehouse"
+              object-name="warehouse"
               type="input"
               :multiple="false"
               :multiple-limit="1"
@@ -39,49 +40,46 @@
             />
           </template>
         </van-field>
-        <van-field
+        <dc-select-dialog
           v-if="formData.inType === 'DC_WMS_IN_TYPE_RETURN'"
+          v-model="formData.inSourceNumber"
           label="来源单号"
-        >
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.inSourceNumber"
-              objectName="outboundOrder"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :params="{
-                outStockStatus: 'DC_WMS_OUT_STATUS_BORROW',
-              }"
-              @change="(row) => handleWarehouseChange(row, 'outboundOrder')"
-            />
-          </template>
-        </van-field>
+          object-name="outboundOrder"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :params="{
+            outStockStatus: 'DC_WMS_OUT_STATUS_BORROW',
+          }"
+          @change="(row) => handleWarehouseChange(row, 'outboundOrder')"
+        />
         <van-field v-else label="来源单号">
           <template #input>
             <van-field
               v-model="formData.inSourceNumber"
               placeholder="请输入选择来源单号"
-              @blur="handleSerch"
               :readonly="formData.inType === 'DC_WMS_IN_TYPE_OTHER'"
+              @blur="handleSerch"
             />
           </template>
         </van-field>
-        <van-field label="申请人">
-          <template #input>
-            <dc-select-user v-model="formData.applicantId" placeholder="请选择" :multipleLimit="1" />
-          </template>
-        </van-field>
-        <van-field label="处理人">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multipleLimit="1"
-            />
-          </template>
-        </van-field>
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          :disabled="isShow"
+        />
         <van-field
           v-if="formData.reject"
           v-model="formData.reject"
@@ -93,15 +91,12 @@
       </van-cell-group>
       <div class="form-group-title">入库明细</div>
       <van-button v-if="btnOpen" class="mb-5" type="primary" @click="addRow">新增</van-button>
-      <van-uploader
-        v-if="btnOpen"
-        :after-read="uploadFile"
-        accept=".xls,.xlsx"
-        class="ml-2 mr-2"
-      >
+      <van-uploader v-if="btnOpen" :after-read="uploadFile" accept=".xls,.xlsx" class="ml-2 mr-2">
         <van-button type="primary">导入</van-button>
       </van-uploader>
-      <van-button v-if="btnOpen" class="mb-5" type="primary" @click="addExport">下载模板</van-button>
+      <van-button v-if="btnOpen" class="mb-5" type="primary" @click="addExport"
+        >下载模板</van-button
+      >
       <van-cell-group inset class="tabel-border">
         <van-cell
           v-for="(item, index) in formData.detailList"
@@ -118,8 +113,8 @@
                 仓位：
                 <dc-view
                   v-model="item.locationId"
-                  objectName="warehouseLocation"
-                  showKey="locationName"
+                  object-name="warehouseLocation"
+                  show-key="locationName"
                 />
               </div>
               <div class="detail-actions">
@@ -181,7 +176,7 @@
               <dc-select-dialog
                 v-model="formDataTable.locationId"
                 placeholder="请点击仓位编号"
-                objectName="warehouseLocation"
+                object-name="warehouseLocation"
                 type="input"
                 :multiple="false"
                 :multiple-limit="1"

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
@@ -4,64 +4,54 @@
       <div class="form-group-title">基本信息</div>
       <van-cell-group inset>
         <van-field label="入库类型" :model-value="inTypeLabel" readonly />
-        <van-field label="仓库名称">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              object-name="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="show"
-            />
-          </template>
-        </van-field>
-        <van-field label="来源单号">
-          <template #input>
-            <dc-select-dialog
-              v-if="formData.inType === 'DC_WMS_IN_TYPE_RETURN'"
-              v-model="formData.inSourceNumber"
-              object-name="outboundOrder"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="show"
-              :params="{
-                outStockStatus: 'DC_WMS_OUT_STATUS_BORROW',
-              }"
-              @change="(row) => handleWarehouseChange(row, 'outboundOrder')"
-            />
-            <van-field
-              v-else
-              v-model="formData.inSourceNumber"
-              placeholder="请输入来源单号点击查询"
-              readonly
-            />
-          </template>
-        </van-field>
-        <van-field label="申请人">
-          <template #input>
-            <dc-select-user
-              v-model="formData.applicantId"
-              placeholder="请选择"
-              :multiple-limit="1"
-              disabled
-            />
-          </template>
-        </van-field>
-        <van-field label="处理人">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multiple-limit="1"
-              disabled
-            />
-          </template>
-        </van-field>
+        <dc-select-dialog
+          v-model="formData.warehouseId"
+          label="仓库名称"
+          placeholder="请点击选择仓库"
+          object-name="warehouse"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="show"
+        />
+        <dc-select-dialog
+          v-if="formData.inType === 'DC_WMS_IN_TYPE_RETURN'"
+          v-model="formData.inSourceNumber"
+          label="来源单号"
+          object-name="outboundOrder"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="show"
+          :params="{
+            outStockStatus: 'DC_WMS_OUT_STATUS_BORROW',
+          }"
+          @change="(row) => handleWarehouseChange(row, 'outboundOrder')"
+        />
+        <van-field
+          v-else
+          v-model="formData.inSourceNumber"
+          placeholder="请输入来源单号点击查询"
+          readonly
+        />
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          disabled
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          disabled
+        />
       </van-cell-group>
       <div class="form-group-title">入库明细</div>
       <van-cell-group inset class="tabel-border">
@@ -84,7 +74,7 @@
                   show-key="locationName"
                 />
               </div>
-              <div class="detail-actions" v-if="btnOpen">
+              <div v-if="btnOpen" class="detail-actions">
                 <van-button size="small" type="primary" plain @click="handleUpdate(item)">
                   编辑
                 </van-button>
@@ -174,9 +164,8 @@ const pageData = reactive({
   unitList: [],
 });
 
-const { loading, rules, formData, show, open, title, formDataTable, btnOpen, unitList } = toRefs(
-  pageData
-);
+const { loading, rules, formData, show, open, title, formDataTable, btnOpen, unitList } =
+  toRefs(pageData);
 const inTypeLabel = computed(() => {
   const list = DC_WMS_IN_TYPE_WMS?.value || [];
   const hit = list.find((item) => item.dictKey === formData.value.inType);

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
@@ -4,45 +4,38 @@
       <div class="form-group-title">基本信息</div>
       <van-cell-group inset>
         <van-field label="入库类型" :model-value="inTypeLabel" readonly />
-        <van-field label="仓库名称">
-          <template #input>
-            <dc-select-dialog
-              v-model="formData.warehouseId"
-              placeholder="请点击选择仓库"
-              object-name="warehouse"
-              type="input"
-              :multiple="false"
-              :multiple-limit="1"
-              :clearable="true"
-              :disabled="show"
-            />
-          </template>
-        </van-field>
+        <dc-select-dialog
+          v-model="formData.warehouseId"
+          label="仓库名称"
+          placeholder="请点击选择仓库"
+          object-name="warehouse"
+          type="input"
+          :multiple="false"
+          :multiple-limit="1"
+          :clearable="true"
+          :disabled="show"
+        />
         <van-field label="来源单号">
           <template #input>
             <van-field v-model="formData.inSourceNumber" readonly />
           </template>
         </van-field>
-        <van-field label="申请人">
-          <template #input>
-            <dc-select-user
-              v-model="formData.applicantId"
-              placeholder="请选择"
-              :multiple-limit="1"
-              disabled
-            />
-          </template>
-        </van-field>
-        <van-field label="处理人">
-          <template #input>
-            <dc-select-user
-              v-model="formData.processingPersonnel"
-              placeholder="请选择"
-              :multiple-limit="1"
-              disabled
-            />
-          </template>
-        </van-field>
+        <dc-select-dialog
+          v-model="formData.applicantId"
+          label="申请人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          disabled
+        />
+        <dc-select-dialog
+          v-model="formData.processingPersonnel"
+          label="处理人"
+          placeholder="请选择"
+          object-name="user"
+          :multiple="false"
+          disabled
+        />
       </van-cell-group>
       <div class="form-group-title">入库明细</div>
       <van-cell-group inset class="tabel-border">


### PR DESCRIPTION
### Motivation
- The warehousing entry page title incorrectly indicated borrowing while this list is for assembly tool returns. 
- Update the UI text to accurately reflect the page purpose and match surrounding navigation. 

### Description
- Change the nav bar title from "装配工具借用" to "装配工具归还" in `src/views/apps/warehouseRecord/warehousingEntry.vue`.
- This is a UI text change only and does not modify business logic or API calls.

### Testing
- Attempted to run the development server with `npm run dev`, Vite started successfully but the environment reported `spawn xdg-open ENOENT` when trying to open the browser.
- Attempted to capture a screenshot with Playwright, but the Chromium process crashed so no visual snapshot could be produced.
- No automated unit tests were modified or executed for this text-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dcbbf9f708327b801ed1fa3393a7a)