### PR TITLE
Fix warehousing entry navigation routes

### DIFF
--- a/src/router/modules/apps.js
+++ b/src/router/modules/apps.js
@@ -155,6 +155,12 @@ export default {
       component: () => import('@/views/apps/warehouseRecord/warehousingEntry.vue'),
     },
     {
+      path: 'warehouse-record/entry/:id',
+      name: 'appsWarehousingEntrySubmit',
+      meta: { title: '入库提交', requiresAuth: true },
+      component: () => import('@/views/apps/warehouseRecord/warehousingEntry/index.vue'),
+    },
+    {
       path: 'warehouse-record/outbound/:id',
       name: 'appsWarehouseRecordOutboundSubmit',
       meta: { title: '出库提交', requiresAuth: true },

--- a/src/views/apps/warehouseRecord/warehousingEntry.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry.vue
@@ -161,11 +161,11 @@ async function fetcher({ pageNo, pageSize, keyword, status, inType, warehouseId 
 }
 
 const handleAdd = () => {
-  router.push({ name: '入库提交', params: { id: 'create' } });
+  router.push({ name: 'appsWarehousingEntrySubmit', params: { id: 'create' } });
 };
 
 const handleEdit = (row) => {
-  router.push({ name: '入库提交', params: { id: row.id } });
+  router.push({ name: 'appsWarehousingEntrySubmit', params: { id: row.id } });
 };
 
 const handleDelete = async (row) => {

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
@@ -317,10 +317,7 @@ const submitForm = () => {
       loading.value = false;
       if (code === 200) {
         showToast({ type: 'success', message: '保存成功' });
-        router.push({
-          path: '/wms/warehouseRecord/warehousingEntry',
-          params: {},
-        });
+        router.push({ name: 'appsWarehousingEntry' });
       }
     } catch (err) {
       loading.value = false;
@@ -382,10 +379,7 @@ const submitAudit = () => {
     if (code === 200) {
       showToast({ type: 'success', message: '审核成功' });
       loading.value = false;
-      router.push({
-        path: '/wms/warehouseRecord/warehousingEntry',
-        params: {},
-      });
+      router.push({ name: 'appsWarehousingEntry' });
     }
   })();
 };
@@ -434,10 +428,7 @@ const closeDrawer = () => {
 };
 // 取消
 const cancelSubmit = () => {
-  router.push({
-    path: '/wms/warehouseRecord/warehousingEntry',
-    params: {},
-  });
+  router.push({ name: 'appsWarehousingEntry' });
 };
 
 const handleSerch = async (row) => {

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
@@ -563,10 +563,38 @@ const addExport = () => {
 :deep(.van-cell-group) {
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  margin: 0;
+}
+:deep(.van-cell-group--inset) {
+  margin: 0;
 }
 :deep(.van-cell) {
   padding-left: 12px;
   padding-right: 12px;
+}
+.dialog-search-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 0;
+}
+.detail-values {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: right;
+}
+.qty-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
 }
 .form-itme-btn {
   position: fixed;
@@ -595,10 +623,6 @@ const addExport = () => {
 .card__meta .label {
   color: #888;
   min-width: 40px;
-}
-.detail-actions {
-  justify-content: flex-end;
-  gap: 8px;
 }
 .drawer-popup {
   width: 85%;

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
@@ -217,10 +217,7 @@ const submitAudit = () => {
     const { code, msg } = res.data;
     if (code === 200) {
       showToast({ type: 'success', message: '审核成功' });
-      router.push({
-        path: '/wms/warehouseRecord/warehousingEntry',
-        params: {},
-      });
+      router.push({ name: 'appsWarehousingEntry' });
     }
   })();
 };
@@ -261,10 +258,7 @@ const submitReject = async () => {
     const { code, msg } = res.data;
     if (code === 200) {
       showToast({ type: 'success', message: '驳回成功' });
-      router.push({
-        path: '/wms/warehouseRecord/warehousingEntry',
-        params: {},
-      });
+      router.push({ name: 'appsWarehousingEntry' });
     }
   } catch (error) {
     console.error('Reject cancelled or failed:', error);
@@ -272,10 +266,7 @@ const submitReject = async () => {
 };
 
 const cancelSubmit = () => {
-  router.push({
-    path: '/wms/warehouseRecord/warehousingEntry',
-    params: {},
-  });
+  router.push({ name: 'appsWarehousingEntry' });
 };
 
 const handleUpdate = (row) => {

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
@@ -292,6 +292,10 @@ const closeDrawer = () => {
 :deep(.van-cell-group) {
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  margin: 0;
+}
+:deep(.van-cell-group--inset) {
+  margin: 0;
 }
 :deep(.van-cell) {
   padding-left: 12px;
@@ -324,9 +328,6 @@ const closeDrawer = () => {
 .card__meta .label {
   color: #888;
   min-width: 40px;
-}
-.detail-actions {
-  justify-content: flex-end;
 }
 .drawer-popup {
   width: 85%;

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
@@ -123,10 +123,7 @@ onMounted(() => {
 });
 
 const cancelSubmit = () => {
-  router.push({
-    path: '/wms/warehouseRecord/warehousingEntry',
-    params: {},
-  });
+  router.push({ name: 'appsWarehousingEntry' });
 };
 </script>
 <style lang="scss" scoped>

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step3.vue
@@ -136,6 +136,10 @@ const cancelSubmit = () => {
 :deep(.van-cell-group) {
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  margin: 0;
+}
+:deep(.van-cell-group--inset) {
+  margin: 0;
 }
 :deep(.van-cell) {
   padding-left: 12px;


### PR DESCRIPTION
### Motivation
- Fix inconsistent or incomplete route navigation for the warehousing entry flow under `warehouseRecord/warehousingEntry`.
- Provide a dedicated submit route so list-to-submit navigation uses a stable named route.
- Ensure step components return to the list view via the named route instead of hardcoded paths.

### Description
- Added a new route `warehouse-record/entry/:id` named `appsWarehousingEntrySubmit` in `src/router/modules/apps.js` that loads the submit page component `warehousingEntry/index.vue`.
- Updated the list view `handleAdd` and `handleEdit` in `src/views/apps/warehouseRecord/warehousingEntry.vue` to use the new `appsWarehousingEntrySubmit` named route.
- Replaced direct path-based returns (`router.push({ path: '/wms/warehouseRecord/warehousingEntry' })`) with a named route return `router.push({ name: 'appsWarehousingEntry' })` in `step1.vue`, `step2.vue`, and `step3.vue`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f76c66878832793f1bc71860d8b73)