### PR TITLE
Align warehousing entry step button styles with outbound order

### DIFF
--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue
@@ -153,14 +153,14 @@
       </div>
     </div>
 
-    <div class="bottom-bar van-safe-area-bottom">
-      <van-button type="primary" size="small" block :loading="loading" @click="submitForm">
+    <div class="form-itme-btn van-safe-area-bottom">
+      <van-button size="small" block :disabled="loading" @click="cancelSubmit">取消</van-button>
+      <van-button type="success" size="small" block :loading="loading" @click="submitForm">
         保存
       </van-button>
       <van-button type="primary" size="small" block :loading="loading" @click="submitAudit">
         审核
       </van-button>
-      <van-button size="small" block :disabled="loading" @click="cancelSubmit">取消</van-button>
     </div>
 
     <div class="bottom-spacer"></div>
@@ -551,16 +551,16 @@ const addExport = () => {
   margin-top: 8px;
 }
 
-.bottom-bar {
+.form-itme-btn {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
-  padding: 8px 10px;
+  padding: 8px;
   background: #fff;
   display: flex;
+  align-items: center;
   gap: 8px;
-  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .bottom-spacer {

--- a/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
+++ b/src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue
@@ -98,9 +98,9 @@
       </div>
     </div>
     <div class="form-itme-btn">
-      <van-button type="primary" size="small" block @click="submitAudit">通过</van-button>
-      <van-button type="primary" size="small" block @click="submitReject">驳回</van-button>
       <van-button size="small" block @click="cancelSubmit">取消</van-button>
+      <van-button type="danger" size="small" block @click="submitReject">驳回</van-button>
+      <van-button type="primary" size="small" block @click="submitAudit">通过</van-button>
     </div>
   </van-form>
 


### PR DESCRIPTION
### Motivation
- Make the button ordering and visual emphasis in the warehousing entry (装配借用/归还) steps consistent with the `outboundOrder` step UI for a unified user experience. 
- Use the same footer layout class so layout/spacing of action buttons matches other steps. 
- Improve clarity of primary actions by adjusting button colors (`success`/`primary`/`danger`) to match established patterns. 

### Description
- Replaced the `bottom-bar` footer in `src/views/apps/warehouseRecord/warehousingEntry/components/step1.vue` with the `.form-itme-btn` footer and reordered buttons to: `取消`, `保存` (type `success`), `审核` (type `primary`).
- Reordered action buttons in `src/views/apps/warehouseRecord/warehousingEntry/components/step2.vue` to: `取消`, `驳回` (type `danger`), `通过` (type `primary`) to mirror `outboundOrder` ordering and colors.
- Moved and adjusted footer CSS into `.form-itme-btn` (padding and alignment tweaks) so the footer layout matches the outbound order step styles.
- Modified only the two view files above; no API or business logic changes were made.

### Testing
- Launched the dev server with `npm run dev` and Vite started successfully (local server available). 
- Captured a visual verification screenshot using Playwright which produced `artifacts/.../warehousing-entry-buttons.png` to confirm button layout. 
- No unit or integration test changes were required and no automated test suites were executed. 
- Changes were committed locally after verification (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607d1373488327a2bdfb74a3121214)