### PR TITLE
Improve i18n for social/silent login (fallback, retry, CTA)

### DIFF
--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -58,17 +58,21 @@ export default {
       subtitle: 'Delivering a unified, convenient, and secure sign-in experience',
       currentEntry: 'Current entry: {type}',
       loading: 'Signing you in…',
+      fallbackTitle: 'Sign-in failed',
+      fallbackDesc: 'We could not complete the third-party sign-in. Use account login instead.',
       typeLabels: {
         campusApplicant: 'Campus recruitment',
         internalReferral: 'Internal referral',
         vendorHr: 'Vendor HR',
       },
       errors: {
+        generic: 'Sign-in failed. Please use account login.',
         missingRedirect: 'Authorize response missing redirect url',
         missingToken: 'Login failed: access token is missing',
         initAccount: 'Failed to initialize the account, please try again later',
       },
-      goAccountLogin: 'go account login',
+      goAccountLogin: 'Go to account login',
+      retry: 'Try again',
     },
     ticketTransfer: {
       title: 'Preparing your workspace',

--- a/src/locales/vi-VN.js
+++ b/src/locales/vi-VN.js
@@ -58,17 +58,22 @@ export default {
       subtitle: 'Mang đến trải nghiệm đăng nhập thống nhất, tiện lợi và an toàn',
       currentEntry: 'Cổng hiện tại: {type}',
       loading: 'Đang đăng nhập…',
+      fallbackTitle: 'Đăng nhập thất bại',
+      fallbackDesc:
+        'Không thể hoàn tất đăng nhập bên thứ ba. Bạn có thể dùng đăng nhập tài khoản.',
       typeLabels: {
         campusApplicant: 'Tuyển dụng sinh viên',
         internalReferral: 'Giới thiệu nội bộ',
         vendorHr: 'HR nhà cung cấp',
       },
       errors: {
+        generic: 'Đăng nhập thất bại. Vui lòng dùng đăng nhập tài khoản.',
         missingRedirect: 'Phản hồi ủy quyền thiếu địa chỉ chuyển hướng',
         missingToken: 'Đăng nhập thất bại: thiếu access_token',
         initAccount: 'Khởi tạo tài khoản thất bại, vui lòng thử lại sau',
       },
-      goAccountLogin: 'go account login',
+      goAccountLogin: 'Chuyển đến đăng nhập tài khoản',
+      retry: 'Thử lại',
     },
     ticketTransfer: {
       title: 'Đang chuẩn bị môi trường làm việc',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -58,17 +58,21 @@ export default {
       subtitle: '为你提供统一、便捷、安全的登录体验',
       currentEntry: '当前入口：{type}',
       loading: '正在登录中…',
+      fallbackTitle: '登录失败',
+      fallbackDesc: '无法完成第三方登录，你可以使用账号密码登录。',
       typeLabels: {
         campusApplicant: '校园招聘',
         internalReferral: '内部内推',
         vendorHr: '供应商HR',
       },
       errors: {
+        generic: '登录失败，请使用账号密码登录',
         missingRedirect: '授权返回缺少跳转地址',
         missingToken: '登录失败：未获取到 access_token',
         initAccount: '初始化账号失败，请稍后重试',
       },
       goAccountLogin: '前往账号密码登录',
+      retry: '重试',
     },
     ticketTransfer: {
       title: '正在准备工作环境',


### PR DESCRIPTION
### Motivation
- Complete and standardize missing localization copy used by the social/silent login flow so UI can show proper fallback messages, retry labels and clearer account-login call-to-action across locales.

### Description
- Added `fallbackTitle`, `fallbackDesc`, `retry`, and a generic `errors.generic` message under `social` in `src/locales/zh-CN.js`, `src/locales/en-US.js`, and `src/locales/vi-VN.js`, and adjusted the English/Vietnamese account login CTA wording.

### Testing
- No automated tests were run because this change only updates localization strings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731246f62883278f58585be0c6f211)